### PR TITLE
現在の受付ページの機能項目の分離

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/IndexController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/IndexController.java
@@ -6,6 +6,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class IndexController {
 
+  @GetMapping("/main")
+  public String main_page() {
+    return "main.html";
+  }
+
   @GetMapping("/create_gameroom")
   public String create_gameroom() {
     return "";

--- a/src/main/java/oit/is/team7/quiz_7/security/Quiz7AuthConfiguration.java
+++ b/src/main/java/oit/is/team7/quiz_7/security/Quiz7AuthConfiguration.java
@@ -28,6 +28,8 @@ public class Quiz7AuthConfiguration {
             .logoutUrl("/logout")
             .logoutSuccessUrl("/")) // ログアウト後に / にリダイレクト
         .authorizeHttpRequests(authz -> authz
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/main/**"))
+            .authenticated()
             .requestMatchers(AntPathRequestMatcher.antMatcher("/**"))
             .permitAll())// 全員アクセス可能
         .csrf(csrf -> csrf

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -89,8 +89,9 @@
     </header>
 
     <div class="links-section">
-      <a href="/main">ログイン</a><br />
-      <a href="/register_useracc">新規ユーザ登録</a>
+      <a href="/create_gameroom">ゲームルーム作成</a><br />
+      <a href="/join_gameroom">ゲームルーム参加</a><br />
+      <a href="/logout">ログアウト</a><br />
     </div>
   </div>
 </body>


### PR DESCRIPTION
ログインとユーザ新規登録を先に求める構成のサービスにするために，ページの構成・遷移を改訂する．
<static/index.html>
　　・ ログイン　　・ ユーザ新規登録
<templates/main.html>
　　・ ゲームルーム作成　　・ ゲームルーム参加　　・ ログアウト
[DoD] index.htmlの「ログイン」からSpring Securityのログインページに遷移し，認証を受けることができ，その後もう一方のtemplates/main.htmlに遷移できること．
