### PR TITLE
ユーザアカウント権限(userRoles)のDBスキーマの権限カラム(roles)の外部キー参照化

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,17 @@
+INSERT INTO roleList (roles)
+  SELECT 'USER'
+  WHERE NOT EXISTS (
+    SELECT 1 FROM roleList
+      WHERE id = (SELECT id FROM roleList WHERE roles = 'USER')
+  );
+
+INSERT INTO roleList (roles)
+  SELECT 'ADMIN'
+  WHERE NOT EXISTS (
+    SELECT 1 FROM roleList
+      WHERE id = (SELECT id FROM roleList WHERE roles = 'ADMIN')
+  );
+
 -- デバッグ用ユーザアカウントのデータ
 -- name: "A", pass: "a"
 INSERT INTO userAccount (userName, pass)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,6 +11,12 @@ CREATE TABLE IF NOT EXISTS userAccount (
   available BOOLEAN DEFAULT TRUE -- アカウントが利用可能(有効)であるかを示す0/1フラグ．TRUEならば利用可能，FALSEならば利用不可能(アカウント停止)を示す．
 );
 
+CREATE TABLE IF NOT EXISTS roleList (
+  id IDENTITY PRIMARY KEY,
+  roles VARCHAR,
+  UNIQUE(roles)
+);
+
 -- ユーザアカウント役職(roles, authorities)管理テーブル (Author: Yura-Mp)
 /* <Updated: 2024/11/24>
  * 　Spring Securityでは，単一のユーザアカウントに対して複数の役職
@@ -20,6 +26,6 @@ CREATE TABLE IF NOT EXISTS userAccount (
 */
 CREATE TABLE IF NOT EXISTS userRoles (
   id IDENTITY REFERENCES userAccount(id), -- ユーザID．ユーザアカウントデータテーブル(id)を外部キー参照．
-  roles VARCHAR, -- ユーザが属する役職．
+  roles VARCHAR REFERENCES roleList(roles), -- ユーザが属する役職．
   UNIQUE(id, roles) -- 複合主キー(扱い)．
 );


### PR DESCRIPTION
モブプログラミングで実装
[DoD] 
・ 次の項目を満たすテーブルがh2-consoleまたはschema.sqlにて確認できること．
　・ テーブル名が「roleList」
　・ カラムが固有なIDに権限名(roles)が対応する形であること．
　・ 固有なIDが主キーであること．
　・ 権限名の重複を許さないこと．
・既存のユーザアカウント権限管理テーブル(userRoles)の権限カラム(roles)が，上記のテーブルを外部キーとして参照していることを確認できること．