### PR TITLE
ゲームルームページの実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
@@ -1,0 +1,49 @@
+package oit.is.team7.quiz_7.controller;
+
+import java.security.Principal;
+import java.util.ArrayList;
+
+import org.springframework.beans.factory.annotation.Autowired;
+// import org.h2.engine.User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import oit.is.team7.quiz_7.model.Gameroom;
+import oit.is.team7.quiz_7.model.GameroomMapper;
+import oit.is.team7.quiz_7.model.UserAccountMapper;
+
+@Controller
+@RequestMapping("/gameroom")
+public class GameroomController {
+  @Autowired
+  UserAccountMapper userAccountMapper;
+  @Autowired
+  GameroomMapper gameroomMapper;
+
+  @GetMapping
+  public String gameroom(Principal principal, ModelMap model) {
+    int userId = userAccountMapper.selectUserAccountByUsername(principal.getName()).getId();
+    ArrayList<Gameroom> gameroomList = gameroomMapper.selectGameroomByHostUserID(userId);
+    model.addAttribute("gameroomList", gameroomList);
+    return "gameroom.html";
+  }
+
+  @GetMapping("/create")
+  public String create_gameroom() {
+    return "";
+  }
+
+  @GetMapping("/prepare_open")
+  public String prepare_open_gameroom(@RequestParam("room") int roomID, ModelMap model) {
+    return "";
+  }
+
+  @GetMapping("/delete")
+  public String delete_gameroom(@RequestParam("room") int roomID, ModelMap model) {
+    return "";
+  }
+
+}

--- a/src/main/java/oit/is/team7/quiz_7/controller/IndexController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/IndexController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import oit.is.team7.quiz_7.model.GameroomMapper;
 import oit.is.team7.quiz_7.model.UserAccount;
 import oit.is.team7.quiz_7.model.UserAccountMapper;
 import oit.is.team7.quiz_7.security.Quiz7AuthConfiguration;
@@ -20,15 +21,12 @@ import oit.is.team7.quiz_7.security.Quiz7AuthConfiguration;
 public class IndexController {
   @Autowired
   UserAccountMapper userAccountMapper;
+  @Autowired
+  GameroomMapper gameroomMapper;
 
   @GetMapping("/main")
   public String main_page() {
     return "main.html";
-  }
-
-  @GetMapping("/create_gameroom")
-  public String create_gameroom() {
-    return "";
   }
 
   @GetMapping("/join_gameroom")
@@ -78,4 +76,5 @@ public class IndexController {
     model.addAttribute("result", "User account created successfully.");
     return "register_useracc.html";
   }
+
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/Gameroom.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/Gameroom.java
@@ -1,0 +1,50 @@
+package oit.is.team7.quiz_7.model;
+
+public class Gameroom {
+  int ID;
+  int hostUserID;
+  String roomName;
+  String description;
+  boolean published;
+
+  public int getID() {
+    return ID;
+  }
+
+  public void setID(int iD) {
+    ID = iD;
+  }
+
+  public int getHostUserID() {
+    return hostUserID;
+  }
+
+  public void setHostUserID(int hostUserID) {
+    this.hostUserID = hostUserID;
+  }
+
+  public String getRoomName() {
+    return roomName;
+  }
+
+  public void setRoomName(String roomName) {
+    this.roomName = roomName;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public boolean isPublished() {
+    return published;
+  }
+
+  public void setPublished(boolean published) {
+    this.published = published;
+  }
+
+}

--- a/src/main/java/oit/is/team7/quiz_7/model/GameroomMapper.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/GameroomMapper.java
@@ -1,0 +1,26 @@
+package oit.is.team7.quiz_7.model;
+
+import java.util.ArrayList;
+
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+@Mapper
+public interface GameroomMapper {
+  @Select("SELECT * FROM gameroom WHERE ID = #{ID}")
+  Gameroom selectGameroomByID(int ID);
+
+  @Select("SELECT * FROM gameroom WHERE hostUserID = #{hostUserID}")
+  ArrayList<Gameroom> selectGameroomByHostUserID(int hostUserID);
+
+  @Update("UPDATE gameroom SET published = #{published} WHERE ID = #{ID}")
+  void updatePublishedByID(int ID, boolean published);
+
+  @Insert("INSERT INTO gameroom (hostUserID, roomName, description) VALUES (#{hostUserID}, #{roomName}, #{description})")
+  @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")
+  void insertGameroom(Gameroom gameroom);
+
+}

--- a/src/main/java/oit/is/team7/quiz_7/model/QuizTable.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/QuizTable.java
@@ -1,0 +1,77 @@
+package oit.is.team7.quiz_7.model;
+
+public class QuizTable {
+  int ID;
+  int quizFormatID;
+  int authorID;
+  String title;
+  String description;
+  double timelimit;
+  int point;
+  String quizJSON;
+
+  public int getID() {
+    return ID;
+  }
+
+  public void setID(int iD) {
+    ID = iD;
+  }
+
+  public int getQuizFormatID() {
+    return quizFormatID;
+  }
+
+  public void setQuizFormatID(int quizFormatID) {
+    this.quizFormatID = quizFormatID;
+  }
+
+  public int getAuthorID() {
+    return authorID;
+  }
+
+  public void setAuthorID(int authorID) {
+    this.authorID = authorID;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public double getTimelimit() {
+    return timelimit;
+  }
+
+  public void setTimelimit(double timelimit) {
+    this.timelimit = timelimit;
+  }
+
+  public int getPoint() {
+    return point;
+  }
+
+  public void setPoint(int point) {
+    this.point = point;
+  }
+
+  public String getQuizJSON() {
+    return quizJSON;
+  }
+
+  public void setQuizJSON(String quizJSON) {
+    this.quizJSON = quizJSON;
+  }
+
+}

--- a/src/main/java/oit/is/team7/quiz_7/model/QuizTableMapper.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/QuizTableMapper.java
@@ -1,0 +1,19 @@
+package oit.is.team7.quiz_7.model;
+
+import java.util.ArrayList;
+
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface QuizTableMapper {
+  @Select("SELECT * FROM quizTable WHERE ID = #{ID}")
+  QuizTable selectQuizTableByID(int ID);
+
+  @Select("SELECT * FROM quizTable WHERE authorID = #{authorID}")
+  ArrayList<QuizTable> selectQuizTableByAuthorID(int authorID);
+
+  @Delete("DELETE FROM quizTable WHERE ID = #{ID}")
+  void deleteQuizTableByID(int ID);
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -35,4 +35,12 @@ INSERT INTO quizFormatList (quizFormat)
         WHERE quizFormat = '4choices'
     );
 
+INSERT INTO gameroom (hostUserID, roomName, description)
+  SELECT (SELECT id FROM userAccount WHERE userName = 'A'), 'testroom', 'This is a test room.'
+  WHERE NOT EXISTS (
+    SELECT 1 FROM gameroom
+      WHERE hostUserID = (SELECT id FROM userAccount WHERE userName = 'A')
+        AND roomName = 'testroom'
+  );
+
 COMMIT;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS roleList (
 
 -- ユーザアカウント役職(roles, authorities)管理テーブル (Author: Yura-Mp)
 /* <Updated: 2024/11/24>
- * 　Spring Securityでは，単一のユーザアカウントに対して複数の役職
+ * Spring Securityでは，単一のユーザアカウントに対して複数の役職
  * (roles, authorities) に属し得ることを想定しているため，ユーザアカウントと役職とを
  * 多対多関連で対としたテーブルを組み込む．
  * この事実により，当初のDBスキーマから要所において変更が成されている．

--- a/src/main/resources/static/css/origin.css
+++ b/src/main/resources/static/css/origin.css
@@ -72,3 +72,9 @@ h1 {
   background-color: #add8e6;
   color: white;
 }
+
+.links-section ul li a {
+  text-decoration: underline;
+  border: none;
+  margin-left: 10px;
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title>Quiz_7</title>
-  <link rel="stylesheet" href="css/origin.css" />
+  <link rel="stylesheet" href="/css/origin.css" />
 </head>
 
 <body>

--- a/src/main/resources/templates/gameroom.html
+++ b/src/main/resources/templates/gameroom.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/ゲームルーム</title>
+  <link rel="stylesheet" href="/css/origin.css" />
+</head>
+
+<body>
+  <div class="container">
+    <header class="title-section">
+      <h1>ゲームルーム一覧</h1>
+    </header>
+
+    <div class="links-section">
+      <a href="/gameroom/create" class="button">新規作成</a>
+      <!-- マッピングされた gameroomList を表示 -->
+      <ul th:if="${gameroomList}">
+        <li th:each="gameroom : ${gameroomList}">
+          <span th:text="${gameroom.roomName}"></span>
+          <a th:href="@{/gameroom/prepare_open(room=${gameroom.ID})}">公開準備</a>
+          <a th:href="@{/gameroom/delete(room=${gameroom.ID})}">削除</a>
+        </li>
+      </ul>
+      <a href="/main" class="button">戻る</a>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title>Quiz_7/ログイン</title>
-  <link rel="stylesheet" href="css/origin.css" />
+  <link rel="stylesheet" href="/css/origin.css" />
 </head>
 
 <body>

--- a/src/main/resources/templates/logout.html
+++ b/src/main/resources/templates/logout.html
@@ -3,8 +3,8 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Quiz_7/ログイン</title>
-  <link rel="stylesheet" href="css/origin.css" />
+  <title>Quiz_7/ログアウト</title>
+  <link rel="stylesheet" href="/css/origin.css" />
 </head>
 
 <body>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title>Quiz_7</title>
-  <link rel="stylesheet" href="css/origin.css" />
+  <link rel="stylesheet" href="/css/origin.css" />
 </head>
 
 <body>

--- a/src/main/resources/templates/register_useracc.html
+++ b/src/main/resources/templates/register_useracc.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title>Quiz_7/新規ユーザ登録</title>
-  <link rel="stylesheet" href="css/origin.css" />
+  <link rel="stylesheet" href="/css/origin.css" />
 </head>
 
 <body>


### PR DESCRIPTION
・ログインユーザのゲームルームを一覧表示するページ（gameroom.html）を作成。
・テスト表示用のゲームルームをdata.sqlに追加。
・箇条書きで表示されたリンクの枠線が重なっていたため、origin.cssにスタイルを追加。
・当初「公開（open）」リンクを予定していたが、ゲームルームを公開する処理を行うのではなく、公開前の準備をするページへの遷移を行うものであることから、「公開準備（prepare_open）」リンクに変更して実装。

[DoD]
ユーザアカウントに紐づけられたゲームルームを一覧表示する構造をもったページであること
 一覧表示されたゲームルームそれぞれに，公開準備・削除を行うページへのリンク(「prepare_open・delete」)があること．
ゲームルーム新規作成を行う「create」リンクがあること．
main.htmlに戻るリンクがあること