### PR TITLE
ゲームルーム新規作成ページ(/gameroom/create)のページの実装 の完了

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -31,9 +32,15 @@ public class GameroomController {
     return "gameroom.html";
   }
 
-  @GetMapping("/create")
-  public String create_gameroom() {
-    return "";
+  @GetMapping("create")
+  public String get_create_gameroom() {
+    return "gameroom/create.html";
+  }
+
+  @PostMapping("create")
+  public String post_create_gameroom(@RequestParam String game_room_name, @RequestParam String description,
+      Principal principal, ModelMap model) {
+    return "gameroom/create.html";
   }
 
   @GetMapping("/prepare_open")

--- a/src/main/resources/templates/gameroom/create.html
+++ b/src/main/resources/templates/gameroom/create.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/ログイン</title>
+  <link rel="stylesheet" href="/css/origin.css" />
+  <link rel="stylesheet" href="/css/login.css" />
+</head>
+
+<body>
+  <div class="container">
+    <header class="title-section">
+      <h1>Quiz_7（仮）</h1>
+    </header>
+
+    <div class="links-section">
+      <h2>ゲームルーム新規作成</h2>
+      <p>新しくゲームルームを作成します</p>
+      <hr>
+
+      <form th:action="@{create}" method="post">
+        <label for="game_room_name">ゲームルーム名:</label><br>
+        <input type="text" name="game_room_name" required><br>
+        <label for="description">説明入力欄:</label><br>
+        <textarea name="description" cols="30" rows="5"></textarea><br>
+        <button type="submit">作成</button>
+      </form>
+      <br>
+      <a href="../gameroom" class="button">戻る</a>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
### [概要]
　タスク「ゲームルーム新規作成ページ(/gameroom/create)のページの実装」の実装を行ったPR．

### [レビュアー]

- e1b22103

### [DoD]
　・ページURLが「/gameroom/create」であり，これへのGETリクエストで本ページが表示されること．
　・新規に作成するゲームルームに必要な以下の情報を入力できる入力フォームがページにあること．
　　・ゲームルームの名前を入力できる文字列入力部品．
　　・ゲームルームの説明を入力できる文字入力部品．長文入力に適した大きめのフォームが望ましい．
　　・次の仕様を満たした送信ボタン．
　　　・表示名が「作成」(ゲームルームの新規作成を意味する何らかの文字列)
　　　・ページURLと同じ「/gameroom/create」にPOSTリクエストで送信すること．

### [重要事項]
　スタイルは「css/login.css」を流用した．
　本ページのGetMapping(get_create_gameroomメソッド)とPostMapping(post_create_gameroomメソッド)は，GameroomControllerクラスに実装しているので，参考にしてもらいたい．

### [実行/実装事項]
　(省略)

### [以降の開発についてのメモ]
　(省略)

### [備考]
　なし

(編集完了, 2024/12/07 18:30)