### PR TITLE
ゲームルーム削除ページの実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
@@ -13,7 +13,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import oit.is.team7.quiz_7.model.Gameroom;
 import oit.is.team7.quiz_7.model.GameroomMapper;
+import oit.is.team7.quiz_7.model.QuizTable;
+import oit.is.team7.quiz_7.model.QuizTableMapper;
 import oit.is.team7.quiz_7.model.UserAccountMapper;
+import oit.is.team7.quiz_7.model.HasQuiz;
+import oit.is.team7.quiz_7.model.HasQuizMapper;
 
 @Controller
 @RequestMapping("/gameroom")
@@ -22,6 +26,11 @@ public class GameroomController {
   UserAccountMapper userAccountMapper;
   @Autowired
   GameroomMapper gameroomMapper;
+  @Autowired
+  HasQuizMapper hasQuizMapper;
+
+  @Autowired
+  QuizTableMapper quizTableMapper;
 
   @GetMapping
   public String gameroom(Principal principal, ModelMap model) {
@@ -43,7 +52,21 @@ public class GameroomController {
 
   @GetMapping("/delete")
   public String delete_gameroom(@RequestParam("room") int roomID, ModelMap model) {
-    return "";
+    model.addAttribute("gameroom", gameroomMapper.selectGameroomByID(roomID));
+    ArrayList<HasQuiz> quizIDList = hasQuizMapper.selectHasQuizByRoomID(roomID);
+    ArrayList<QuizTable> quizList = new ArrayList<QuizTable>();
+    for (HasQuiz hasQuiz : quizIDList) {
+      quizList.add(quizTableMapper.selectQuizTableByID(hasQuiz.getQuizID()));
+    }
+    model.addAttribute("quizList", quizList);
+    return "delete_gameroom.html";
+  }
+
+  @GetMapping("/delete/confirm")
+  public String delete_gameroom_confirm(@RequestParam("room") int roomID, ModelMap model) {
+    hasQuizMapper.deleteHasQuizByRoomID(roomID);
+    gameroomMapper.deleteGameroomByID(roomID);
+    return "redirect:/gameroom";
   }
 
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/GameroomMapper.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/GameroomMapper.java
@@ -2,6 +2,7 @@ package oit.is.team7.quiz_7.model;
 
 import java.util.ArrayList;
 
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
@@ -23,4 +24,6 @@ public interface GameroomMapper {
   @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")
   void insertGameroom(Gameroom gameroom);
 
+  @Delete("DELETE FROM gameroom WHERE ID = #{ID}")
+  void deleteGameroomByID(int ID);
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/HasQuiz.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/HasQuiz.java
@@ -1,0 +1,31 @@
+package oit.is.team7.quiz_7.model;
+
+public class HasQuiz {
+  int roomID;
+  int quizID;
+  int index;
+
+  public int getRoomID() {
+    return roomID;
+  }
+
+  public void setRoomID(int roomID) {
+    this.roomID = roomID;
+  }
+
+  public int getQuizID() {
+    return quizID;
+  }
+
+  public void setQuizID(int quizID) {
+    this.quizID = quizID;
+  }
+
+  public int getIndex() {
+    return index;
+  }
+
+  public void setIndex(int index) {
+    this.index = index;
+  }
+}

--- a/src/main/java/oit/is/team7/quiz_7/model/HasQuizMapper.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/HasQuizMapper.java
@@ -1,0 +1,19 @@
+package oit.is.team7.quiz_7.model;
+
+import java.util.ArrayList;
+
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface HasQuizMapper {
+  @Select("SELECT * FROM hasQuiz WHERE roomID = #{roomID}")
+  ArrayList<HasQuiz> selectHasQuizByRoomID(int roomID);
+
+  @Select("SELECT * FROM hasQuiz WHERE quizID = #{quizID}")
+  ArrayList<HasQuiz> selectHasQuizByQuizID(int quizID);
+
+  @Delete("DELETE FROM hasQuiz WHERE roomID = #{roomID}")
+  void deleteHasQuizByRoomID(int roomID);
+}

--- a/src/main/resources/static/css/delete.css
+++ b/src/main/resources/static/css/delete.css
@@ -1,3 +1,4 @@
+/* 基本のテキストスタイル */
 h3,
 p,
 li {
@@ -19,6 +20,7 @@ a {
   transition: background-color 0.3s ease;
 }
 
+/* 通常の表示をするdisplay、白い背景のinput-form */
 .display,
 .input-form {
   flex: 1;
@@ -44,6 +46,7 @@ a {
   margin: 0 auto 20px auto;
 }
 
+/* 色付きボタン */
 .input-form .colored_button {
   display: block;
   background-color: #add8e6;
@@ -61,6 +64,12 @@ a {
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
 
+.input-form .colored_button:hover {
+  background-color: #87ceeb;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+/* 戻るボタン */
 .input-form .button {
   background-color: #ebebeb;
   color: #2c3e50;
@@ -75,11 +84,6 @@ a {
   text-align: center;
   margin: 0 auto;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-}
-
-.input-form .colored_button:hover {
-  background-color: #87ceeb;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
 }
 
 .input-form .button:hover {

--- a/src/main/resources/static/css/delete.css
+++ b/src/main/resources/static/css/delete.css
@@ -1,0 +1,88 @@
+h3,
+p,
+li {
+  font-family: 'Orbitron', sans-serif;
+  color: #2c3e50;
+  letter-spacing: 2px;
+  margin: 0;
+}
+
+a {
+  text-decoration: none;
+  color: #333;
+  font-size: 1.2em;
+  padding: 10px;
+  border: 2px solid #333;
+  border-radius: 5px;
+  width: 80%;
+  text-align: center;
+  transition: background-color 0.3s ease;
+}
+
+.display,
+.input-form {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+}
+
+.input-form {
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 20px;
+  border-radius: 15px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  width: 60%;
+  align-items: center;
+}
+
+.input-form hr {
+  border: none;
+  border-top: 2px solid #2c3e50;
+  width: 90%;
+  margin: 0 auto 20px auto;
+}
+
+.input-form .colored_button {
+  display: block;
+  background-color: #add8e6;
+  color: #555;
+  border: none;
+  padding: 10px 20px;
+  font-size: 1em;
+  font-weight: bold;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  width: 80%;
+  text-align: center;
+  margin: 0 auto;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+.input-form .button {
+  background-color: #ebebeb;
+  color: #2c3e50;
+  border: none;
+  padding: 10px 20px;
+  font-size: 1em;
+  font-weight: bold;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  width: 80%;
+  text-align: center;
+  margin: 0 auto;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+.input-form .colored_button:hover {
+  background-color: #87ceeb;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+.input-form .button:hover {
+  background-color: #dcdcdc;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}

--- a/src/main/resources/templates/delete_gameroom.html
+++ b/src/main/resources/templates/delete_gameroom.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/ゲームルーム削除</title>
+  <link rel="stylesheet" href="/css/origin.css" />
+  <link rel="stylesheet" href="/css/delete.css" />
+</head>
+
+<body>
+  <div class="container">
+    <div class="display">
+      <h3>ゲームルーム情報</h3>
+      <p>ルーム名： <span th:text="${gameroom.roomName}"></span></p>
+      <p>ルーム概要： <span th:text="${gameroom.description}"></span></p>
+
+      <h3>クイズリスト</h3>
+      <ul th:if="${quizList}">
+        <li th:each="quiz : ${quizList}">
+          <span th:text="${quiz.title}"></span>
+        </li>
+      </ul>
+    </div>
+
+    <div class="input-form">
+      <h3>このゲームルームを削除しますか？</h3>
+      <a th:href="@{/gameroom/delete/confirm(room=${gameroom.ID})}" class="colored_button">削除</a><br />
+      <a href="/gameroom" class="button">戻る</a>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
ゲームルームを削除する前の確認ページを作成
削除ページ用のCSSを作成
ゲームルーム（&そのルームとクイズの関連）を削除する処理を実装

[DoD]
- http://localhost/gameroom/delete?room=(ゲームルームID) の形でアクセスするとページが表示されること
- 削除するルームの名前、説明、登録されているクイズが表示されること
- 削除してよいか確認する文言と削除を実行するボタンがあること
- ゲームルーム一覧（/gameroom）に戻るリンクがあること 

今回追加したCSSを一応「delete.css」としていますが、実質的にはこれまでのCSSと同じようなもので、一部内容に重複があります。
login.cssのスタイルをより使い回しやすくしたかったのですが、他のページにまで変更が及ぶとこのタスクの範囲を超えるため、とりあえず新しいCSSファイルを加える形にしました。
ひとまずは提案として見てもらえればと思います。
これが良いという合意を得られたら、またCSSのリファクタリングをして重複を解消したいと思います。