### PR TITLE
ゲームルーム新規作成ページの処理とその結果表示ページの実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
@@ -40,7 +40,19 @@ public class GameroomController {
   @PostMapping("create")
   public String post_create_gameroom(@RequestParam String game_room_name, @RequestParam String description,
       Principal principal, ModelMap model) {
-    return "gameroom/create.html";
+    int hostId = userAccountMapper.selectUserAccountByUsername(principal.getName()).getId();
+    Gameroom gameroom = gameroomMapper.selectGameroomByHostAndName(hostId, game_room_name);
+    if (gameroom != null) {
+      model.addAttribute("error_result", "既に同名のゲームルームが存在しています");
+      return "gameroom/create_result.html";
+    }
+    Gameroom newGameroom = new Gameroom();
+    newGameroom.setHostUserID(hostId);
+    newGameroom.setRoomName(game_room_name);
+    newGameroom.setDescription(description);
+    gameroomMapper.insertGameroom(newGameroom);
+    model.addAttribute("result", "新規のゲームルームを作成しました");
+    return "gameroom/create_result.html";
   }
 
   @GetMapping("/prepare_open")

--- a/src/main/java/oit/is/team7/quiz_7/model/Gameroom.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/Gameroom.java
@@ -1,18 +1,18 @@
 package oit.is.team7.quiz_7.model;
 
 public class Gameroom {
-  int ID;
+  int id;
   int hostUserID;
   String roomName;
   String description;
   boolean published;
 
   public int getID() {
-    return ID;
+    return id;
   }
 
-  public void setID(int iD) {
-    ID = iD;
+  public void setID(int id) {
+    this.id = id;
   }
 
   public int getHostUserID() {

--- a/src/main/java/oit/is/team7/quiz_7/model/GameroomMapper.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/GameroomMapper.java
@@ -10,14 +10,17 @@ import org.apache.ibatis.annotations.Update;
 
 @Mapper
 public interface GameroomMapper {
-  @Select("SELECT * FROM gameroom WHERE ID = #{ID}")
+  @Select("SELECT * FROM gameroom WHERE id = #{id}")
   Gameroom selectGameroomByID(int ID);
 
   @Select("SELECT * FROM gameroom WHERE hostUserID = #{hostUserID}")
   ArrayList<Gameroom> selectGameroomByHostUserID(int hostUserID);
 
-  @Update("UPDATE gameroom SET published = #{published} WHERE ID = #{ID}")
-  void updatePublishedByID(int ID, boolean published);
+  @Select("SELECT * FROM gameroom WHERE hostUserID = #{hostUserID} and roomName = #{roomName}")
+  Gameroom selectGameroomByHostAndName(int hostUserID, String roomName);
+
+  @Update("UPDATE gameroom SET published = #{published} WHERE id = #{id}")
+  void updatePublishedByID(int id, boolean published);
 
   @Insert("INSERT INTO gameroom (hostUserID, roomName, description) VALUES (#{hostUserID}, #{roomName}, #{description})")
   @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")

--- a/src/main/resources/templates/gameroom/create_result.html
+++ b/src/main/resources/templates/gameroom/create_result.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/ゲームルーム新規作成</title>
+  <link rel="stylesheet" href="/css/origin.css" />
+  <link rel="stylesheet" href="/css/login.css" />
+</head>
+
+<body>
+  <div class="container">
+    <header class="title-section">
+      <h1>Quiz_7（仮）</h1>
+    </header>
+
+    <div class="links-section">
+      <h2>ゲームルーム新規作成</h2>
+      <hr>
+
+      <div th:if="${error_result}" class="error-message">[[${error_result}]]
+      </div>
+      <div th:if="${result}">[[${result}]]
+      </div><br>
+      <div th:if="${error_result == null}">
+        <a href="/gameroom/register_quiz">問題登録</a>
+      </div><br>
+      <a href="/gameroom" class="button">戻る</a>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
[概要]
　タスク「ゲームルーム新規作成ページ(/gameroom/create)の処理とその結果表示ページの実装」に関する実装を行ったPR

[レビュアー]
　・ e1b22061

[DoD]
　・新規作成処理後，作成したゲームルームが一覧に表示され，ゲームルーム管理ページ(/gameroom)にて所定の機能が提供されること．
　・新規作成処理後に，次の情報を載せたページが表示されること．
　　　・ 処理結果の表示があること．
　　　・ ゲームルーム管理ページ(/gameroom)に戻るリンクがあること．
　　　・ 新規作成したゲームルームに対する問題登録ページ(/gameroom/register_quiz)に遷移するリンクがあること．

[備考]
　・ログイン中のアカウントが保有するゲームルームの中に、同名のゲームルームが既に存在していた場合、エラー表示をしています。