### PR TITLE
(ゲームルーム紐づけ)問題作成/編集ページ(/gameroom/edit_quiz)の処理の実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'  // 最新バージョンに変更
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'

--- a/src/main/java/oit/is/team7/quiz_7/model/HasQuizMapper.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/HasQuizMapper.java
@@ -3,6 +3,7 @@ package oit.is.team7.quiz_7.model;
 import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 
@@ -13,6 +14,12 @@ public interface HasQuizMapper {
 
   @Select("SELECT * FROM hasQuiz WHERE quizID = #{quizID}")
   ArrayList<HasQuiz> selectHasQuizByQuizID(int quizID);
+
+  @Select("SELECT * FROM hasQuiz WHERE roomID = #{roomID} ORDER BY index DESC LIMIT 1")
+  HasQuiz maxIndexByRoomID(int roomID);
+
+  @Insert("INSERT INTO hasQuiz (roomID, quizID, index) VALUES (#{roomID}, #{quizID}, #{index})")
+  void insertHasQuiz(HasQuiz hasQuiz);
 
   @Delete("DELETE FROM hasQuiz WHERE roomID = #{roomID}")
   void deleteHasQuizByRoomID(int roomID);

--- a/src/main/java/oit/is/team7/quiz_7/model/QuizFormatList.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/QuizFormatList.java
@@ -1,0 +1,22 @@
+package oit.is.team7.quiz_7.model;
+
+public class QuizFormatList {
+  int id;
+  String quizFormat;
+
+  public int getId() {
+    return id;
+  }
+
+  public void setID(int id) {
+    this.id = id;
+  }
+
+  public String getQuizFormat() {
+    return quizFormat;
+  }
+
+  public void setQuizFormat(String quizFormat) {
+    this.quizFormat = quizFormat;
+  }
+}

--- a/src/main/java/oit/is/team7/quiz_7/model/QuizFormatListMapper.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/QuizFormatListMapper.java
@@ -1,0 +1,10 @@
+package oit.is.team7.quiz_7.model;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface QuizFormatListMapper {
+  @Select("SELECT * FROM QuizFormatList WHERE quizFormat = #{quizFormat}")
+  QuizFormatList selectQuizFormatByFormat(String quizFormat);
+}

--- a/src/main/java/oit/is/team7/quiz_7/model/QuizJson.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/QuizJson.java
@@ -1,0 +1,22 @@
+package oit.is.team7.quiz_7.model;
+
+public class QuizJson {
+  public int correct;
+  public String[] choices;
+
+  public int getCorrect() {
+    return correct;
+  }
+
+  public void setCorrect(int correct) {
+    this.correct = correct;
+  }
+
+  public String[] getChoices() {
+    return choices;
+  }
+
+  public void setChoices(String[] choices) {
+    this.choices = choices;
+  }
+}

--- a/src/main/java/oit/is/team7/quiz_7/model/QuizTableMapper.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/QuizTableMapper.java
@@ -3,7 +3,9 @@ package oit.is.team7.quiz_7.model;
 import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 
 @Mapper
@@ -13,6 +15,10 @@ public interface QuizTableMapper {
 
   @Select("SELECT * FROM quizTable WHERE authorID = #{authorID}")
   ArrayList<QuizTable> selectQuizTableByAuthorID(int authorID);
+
+  @Insert("INSERT INTO quizTable (quizFormatID, authorID, title, description, quizJSON) VALUES (#{quizFormatID}, #{authorID}, #{title}, #{description}, #{quizJSON})")
+  @Options(useGeneratedKeys = true, keyColumn = "ID", keyProperty = "ID")
+  void insertQuizTable(QuizTable quizTable);
 
   @Delete("DELETE FROM quizTable WHERE ID = #{ID}")
   void deleteQuizTableByID(int ID);

--- a/src/main/resources/templates/gameroom/edit_quiz.html
+++ b/src/main/resources/templates/gameroom/edit_quiz.html
@@ -5,6 +5,30 @@
   <meta charset="utf-8">
   <title>Quiz_7/問題作成</title>
   <link rel="stylesheet" href="/css/origin.css" />
+  <style>
+    /* メッセージ表示部分 */
+    .links-section .message,
+    .links-section .normal-message,
+    .links-section .error-message {
+      margin-bottom: 20px;
+      padding: 10px;
+    }
+
+    /* 通常メッセージ表示部分 */
+    .links-section .message,
+    .links-section .normal-message {
+      border: 2px solid #000000;
+      background-color: #f0f0f0;
+    }
+
+    /* エラーメッセージ表示部分 */
+    .links-section .error-message {
+      color: #e74c3c;
+      font-weight: bold;
+      border: 2px solid #e74c3c;
+      background-color: #f8d7da;
+    }
+  </style>
 </head>
 
 <body>
@@ -43,6 +67,12 @@
     </div>
 
     <div class="links-section">
+      <div th:if="${result == null and error_result == null}" class="message">全項目を入力してください
+      </div>
+      <div th:if="${error_result}" class="error-message">[[${error_result}]]
+      </div>
+      <div th:if="${result}" class="normal-message">[[${result}]]
+      </div>
       <button type="submit" form="edit_quiz">問題作成/登録</button>
       <a th:href="@{./register_quiz(room=${gameroom.ID})}">戻る</a>
     </div>


### PR DESCRIPTION
Close #32 
[概要]
　タスク「(ゲームルーム紐づけ)問題作成/編集ページ(/gameroom/edit_quiz)の処理の実装」の実装を行ったPR．

[重要事項]
・PR#37「(ゲームルーム紐づけ)問題作成/編集ページ(/gameroom/edit_quiz)のページの実装」で記述のあったpostMethodNameメソッドの名前は変更済み．
・既存cssファイルで記述できていない部分が少しあったため，styleとして記述している．
・問題作成/編集ページは，問題作成ボタンの上に常にメッセージを表示する．エラーに関しては，1つでも空白の項目がある状態で問題作成をしようとした場合に表示されるが，これは仮実装のため後々変更かも．
・Jsonに関しては正しいか不明のため，一旦それらしい形で登録している．