### PR TITLE
ゲームルーム公開前準備ページ(/gameroom/prepare_open)のページの実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
@@ -73,6 +73,12 @@ public class GameroomController {
   @GetMapping("/prepare_open")
   public String get_prepare_open_gameroom(@RequestParam("room") int roomID, ModelMap model) {
     model.addAttribute("gameroom", gameroomMapper.selectGameroomByID(roomID));
+    ArrayList<HasQuiz> quizIDList = hasQuizMapper.selectHasQuizByRoomID(roomID);
+    ArrayList<QuizTable> quizList = new ArrayList<QuizTable>();
+    for (HasQuiz hasQuiz : quizIDList) {
+      quizList.add(quizTableMapper.selectQuizTableByID(hasQuiz.getQuizID()));
+    }
+    model.addAttribute("quizList", quizList);
     return "gameroom/prepare_open.html";
   }
 

--- a/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
@@ -71,7 +71,13 @@ public class GameroomController {
   }
 
   @GetMapping("/prepare_open")
-  public String prepare_open_gameroom(@RequestParam("room") int roomID, ModelMap model) {
+  public String get_prepare_open_gameroom(@RequestParam("room") int roomID, ModelMap model) {
+    model.addAttribute("gameroom", gameroomMapper.selectGameroomByID(roomID));
+    return "gameroom/prepare_open.html";
+  }
+
+  @PostMapping("/prepare_open")
+  public String post_prepare_open_gameroom() {
     return "";
   }
 

--- a/src/main/resources/static/css/origin.css
+++ b/src/main/resources/static/css/origin.css
@@ -250,3 +250,10 @@ select {
   justify-content: space-evenly;
   align-items: center;
 }
+
+/* ラベルと入力欄を横並び */
+.form-inline {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}

--- a/src/main/resources/templates/gameroom/prepare_open.html
+++ b/src/main/resources/templates/gameroom/prepare_open.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/公開準備</title>
+  <link rel="stylesheet" href="/css/origin.css">
+</head>
+
+<body>
+  <div class="container">
+    <div class="display">
+      <h3>ゲームルーム情報</h3>
+      <p>ルーム名： <span th:text="${gameroom.roomName}"></span></p>
+      <p>ルーム概要： <span th:text="${gameroom.description}"></span></p>
+
+      <form th:action="@{/gameroom/prepare_open(room=${gameroom.ID})}" method="post" id="max_players"
+        class="form-inline">
+        <label for="max_players">最大参加人数： </label>
+        <input type="number" name="max_players" size="5" value="50" min="1" max="50" style="width:80px;" />
+      </form>
+    </div>
+
+    <div class="links-section">
+      <button type="submit" form="max_players" class="colored_button">公開</button><br />
+      <a href="../gameroom">戻る</a>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/main/resources/templates/gameroom/prepare_open.html
+++ b/src/main/resources/templates/gameroom/prepare_open.html
@@ -13,17 +13,23 @@
       <h3>ゲームルーム情報</h3>
       <p>ルーム名： <span th:text="${gameroom.roomName}"></span></p>
       <p>ルーム概要： <span th:text="${gameroom.description}"></span></p>
+      <h3>クイズリスト</h3>
+      <ul th:if="${quizList}">
+        <li th:each="quiz : ${quizList}">
+          <span th:text="${quiz.title}"></span>
+        </li>
+      </ul>
 
       <form th:action="@{/gameroom/prepare_open(room=${gameroom.ID})}" method="post" id="max_players"
         class="form-inline">
         <label for="max_players">最大参加人数： </label>
-        <input type="number" name="max_players" size="5" value="50" min="1" max="50" style="width:80px;" />
+        <input type="number" name="max_players" size="5" value="50" min="1" max="50" style="width:80px;" required />
       </form>
     </div>
 
-    <div class="links-section">
+    <div class="input-form">
       <button type="submit" form="max_players" class="colored_button">公開</button><br />
-      <a href="../gameroom">戻る</a>
+      <a href="../gameroom" class="button">戻る</a>
     </div>
   </div>
 </body>


### PR DESCRIPTION
Close #27 
[概要]
　タスク「ゲームルーム公開前準備ページ(/gameroom/prepare_open)のページの実装」の実装を行ったPR．

[備考]
・origin.cssに .form-inline（labelの横に入力欄を表示させるためのcss）を追加した。
・「/gameroom/prepare_open」に対してGETリクエストとPOSTリクエストを行うため、GameroomControllerに元々記述されていたprepare_open_gameroomメソッドをget_prepare_open_gameroomメソッドに変更した。
・DoDには「最大参加人数は無入力を許容」とあるが、デフォルトで50が入力されるよう設定してあるので、required属性を追加して空欄送信を防いでも良いかもしれない。