### PR TITLE
prepare_openのバックエンド処理を実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
@@ -114,7 +114,13 @@ public class GameroomController {
     gameroomMapper.updatePublishedByID(roomID, true);
     logger.info("PGRManager.publicGameRooms:" + this.pGameRoomManager.getPublicGameRooms());
 
-    model.addAttribute("publicGameroom", newPublicGameRoom);
+    return "redirect:/gameroom/standby?room=" + roomID;
+  }
+
+  @GetMapping("/standby")
+  public String standby(@RequestParam("room") int roomID, ModelMap model) {
+    PublicGameRoom publicGameRoom = this.pGameRoomManager.getPublicGameRooms().get((long) roomID);
+    model.addAttribute("publicGameroom", publicGameRoom);
     return "gameroom/standby.html";
   }
 

--- a/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
@@ -2,7 +2,10 @@ package oit.is.team7.quiz_7.controller;
 
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -18,6 +21,8 @@ import oit.is.team7.quiz_7.model.Gameroom;
 import oit.is.team7.quiz_7.model.GameroomMapper;
 import oit.is.team7.quiz_7.model.HasQuiz;
 import oit.is.team7.quiz_7.model.HasQuizMapper;
+import oit.is.team7.quiz_7.model.PGameRoomManager;
+import oit.is.team7.quiz_7.model.PublicGameRoom;
 import oit.is.team7.quiz_7.model.QuizFormatListMapper;
 import oit.is.team7.quiz_7.model.QuizJson;
 import oit.is.team7.quiz_7.model.QuizTable;
@@ -27,6 +32,8 @@ import oit.is.team7.quiz_7.model.UserAccountMapper;
 @Controller
 @RequestMapping("/gameroom")
 public class GameroomController {
+  private final Logger logger = LoggerFactory.getLogger(GameroomController.class);
+
   @Autowired
   UserAccountMapper userAccountMapper;
   @Autowired
@@ -37,6 +44,9 @@ public class GameroomController {
   QuizTableMapper quizTableMapper;
   @Autowired
   QuizFormatListMapper quizFormatListMapper;
+
+  @Autowired
+  PGameRoomManager pGameRoomManager;
 
   @GetMapping
   public String gameroom(Principal principal, ModelMap model) {
@@ -83,8 +93,29 @@ public class GameroomController {
   }
 
   @PostMapping("/prepare_open")
-  public String post_prepare_open_gameroom() {
-    return "";
+  public String post_prepare_open_gameroom(@RequestParam("room") int roomID,
+      @RequestParam("max_players") int max_players, ModelMap model) {
+    Gameroom gameroom = gameroomMapper.selectGameroomByID(roomID);
+    ArrayList<HasQuiz> quizIDList = hasQuizMapper.selectHasQuizByRoomID(roomID);
+    if (quizIDList == null || quizIDList.size() == 0) {
+      logger.error("クイズが登録されていないルームが公開されようとしました");
+      model.addAttribute("gameroom", gameroom);
+      model.addAttribute("error_result", "エラー：このルームにはクイズが登録されていません");
+      return "gameroom/prepare_open.html";
+    }
+    ArrayList<Long> quizPool = new ArrayList<Long>();
+    for (HasQuiz hasQuiz : quizIDList) {
+      quizPool.add((long) hasQuiz.getQuizID());
+    }
+    PublicGameRoom newPublicGameRoom = new PublicGameRoom(roomID, gameroom.getHostUserID(), max_players, quizPool);
+    LinkedHashMap<Long, PublicGameRoom> publicGameRooms = this.pGameRoomManager.getPublicGameRooms();
+    publicGameRooms.put((long) roomID, newPublicGameRoom);
+    this.pGameRoomManager.setPublicGameRooms(publicGameRooms);
+    gameroomMapper.updatePublishedByID(roomID, true);
+    logger.info("PGRManager.publicGameRooms:" + this.pGameRoomManager.getPublicGameRooms());
+
+    model.addAttribute("publicGameroom", newPublicGameRoom);
+    return "gameroom/standby.html";
   }
 
   @GetMapping("/delete")

--- a/src/main/java/oit/is/team7/quiz_7/model/PGameRoomManager.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/PGameRoomManager.java
@@ -6,8 +6,8 @@ import org.springframework.stereotype.Component;
 
 /**
  * @classdesc
- * 本サービスの公開ゲームルームを一元的に管理するクラス(@Component)．
- * 詳しくは本サービスの最新のクラス設計図(quiz_7_ClassGraph_Isdev24_ver*.drawio)を参照．
+ *            本サービスの公開ゲームルームを一元的に管理するクラス(@Component)．
+ *            詳しくは本サービスの最新のクラス設計図(quiz_7_ClassGraph_Isdev24_ver*.drawio)を参照．
  *
  */
 @Component
@@ -16,4 +16,25 @@ public class PGameRoomManager {
 
   private LinkedHashMap<Long, PublicGameRoom> publicGameRooms;
   private LinkedHashMap<Long, Long> belonging;
+
+  public PGameRoomManager() {
+    this.publicGameRooms = new LinkedHashMap<Long, PublicGameRoom>();
+    this.belonging = new LinkedHashMap<Long, Long>();
+  }
+
+  public LinkedHashMap<Long, PublicGameRoom> getPublicGameRooms() {
+    return publicGameRooms;
+  }
+
+  public void setPublicGameRooms(LinkedHashMap<Long, PublicGameRoom> publicGameRooms) {
+    this.publicGameRooms = publicGameRooms;
+  }
+
+  public LinkedHashMap<Long, Long> getBelonging() {
+    return belonging;
+  }
+
+  public void setBelonging(LinkedHashMap<Long, Long> belonging) {
+    this.belonging = belonging;
+  }
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
@@ -5,14 +5,43 @@ import java.util.LinkedHashMap;
 
 /**
  * @classdesc
- * 単一の公開ゲームルームを成すクラス．
- * 詳しくは本サービスの最新のクラス設計図(quiz_7_ClassGraph_Isdev24_ver*.drawio)を参照．
+ *            単一の公開ゲームルームを成すクラス．
+ *            詳しくは本サービスの最新のクラス設計図(quiz_7_ClassGraph_Isdev24_ver*.drawio)を参照．
  *
-*/
+ */
 public class PublicGameRoom {
   private long gameRoomID;
   private long hostUserID;
   private LinkedHashMap<Long, GameRoomParticipant> participants;
   private int maxPlayers = 50;
   private ArrayList<Long> quizPool;
+
+  public PublicGameRoom(long gameRoomID, long hostUserID, int maxPlayers, ArrayList<Long> quizPool) {
+    this.gameRoomID = gameRoomID;
+    this.hostUserID = hostUserID;
+    this.participants = new LinkedHashMap<Long, GameRoomParticipant>();
+    this.maxPlayers = maxPlayers;
+    this.quizPool = quizPool;
+  }
+
+  public long getGameRoomID() {
+    return gameRoomID;
+  }
+
+  public long getHostUserID() {
+    return hostUserID;
+  }
+
+  public LinkedHashMap<Long, GameRoomParticipant> getParticipants() {
+    return participants;
+  }
+
+  public int getMaxPlayers() {
+    return maxPlayers;
+  }
+
+  public ArrayList<Long> getQuizPool() {
+    return quizPool;
+  }
+
 }

--- a/src/main/resources/templates/gameroom/prepare_open.html
+++ b/src/main/resources/templates/gameroom/prepare_open.html
@@ -28,6 +28,7 @@
     </div>
 
     <div class="input-form">
+      <p th:if="${error_result}" th:text="${error_result}" class="error-message"></p>
       <button type="submit" form="max_players" class="colored_button">公開</button><br />
       <a href="../gameroom" class="button">戻る</a>
     </div>

--- a/src/main/resources/templates/gameroom/standby.html
+++ b/src/main/resources/templates/gameroom/standby.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/待機</title>
+  <link rel="stylesheet" href="/css/origin.css">
+</head>
+
+<body>
+  <div class="container">
+    <div class="display">
+      <h3>ゲームルーム情報</h3>
+      <p>ルームID: <span th:text="${publicGameroom.gameRoomID}"></span></p>
+    </div>
+
+    <div class="input-form">
+      <a href="../gameroom" class="button">戻る</a>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/main/resources/templates/playgame.html
+++ b/src/main/resources/templates/playgame.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/ゲームルーム選択</title>
+  <link rel="stylesheet" href="/css/origin.css">
+</head>
+
+<body>
+  <div class="container">
+    <div class="display">
+      <h3>公開ゲームルーム</h3>
+      <table th:if="${publicGameroomList}">
+        <tr th:each="gameroom : ${publicGameroomList}">
+          <td th:text="${gameroom.roomName}"></td>
+          <td th:text="${gameroom.hostName}"></td>
+          <td><a th:href="@{/playgame/join_check(room=${gameroom.ID})}">選択</a></td>
+        </tr>
+      </table>
+
+      <form th:action="@{/gameroom/prepare_open(room=${gameroom.ID})}" method="post" id="max_players"
+        class="form-inline">
+        <label for="max_players">最大参加人数： </label>
+        <input type="number" name="max_players" size="5" value="50" min="1" max="50" style="width:80px;" required />
+      </form>
+    </div>
+
+    <div class="input-form">
+      <button type="submit" form="max_players" class="colored_button">公開</button><br />
+      <a href="../gameroom" class="button">戻る</a>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
Close #42 

開発内容
- GameroomController の post_prepare_open_gameroom() を実装
  - クイズが1つも登録されていないルームを公開しようとした場合、エラーメッセージを表示するようにした
- PublicGameRoom, PGameRoomManager にコンストラクタ、getter/setter を追加
- 動作確認用に GameroomController に Logger を追加、簡易的な /gameroom/standby.html を作成