### PR TITLE
参加者出題待機ページの実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -1,0 +1,24 @@
+package oit.is.team7.quiz_7.controller;
+
+import java.security.Principal;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import oit.is.team7.quiz_7.model.PGameRoomManager;
+
+@Controller
+@RequestMapping("/playing")
+public class PlayingController {
+  @Autowired
+  PGameRoomManager pGameRoomManager;
+
+  @GetMapping("/wait")
+  public String get_wait(Principal prin, ModelMap model) {
+    return "/playing/wait.html";
+  }
+
+}

--- a/src/main/resources/static/css/origin.css
+++ b/src/main/resources/static/css/origin.css
@@ -106,6 +106,13 @@ label {
   margin-bottom: 8px;
 }
 
+/* ラベルと入力欄を横並び */
+.form-inline {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 input,
 textarea {
   width: 100%;
@@ -257,9 +264,17 @@ td {
   align-items: center;
 }
 
-/* ラベルと入力欄を横並び */
-.form-inline {
+/* iframe 表示用 */
+.iframe-section {
   display: flex;
+  justify-content: center;
   align-items: center;
-  gap: 10px;
+  height: auto;
+}
+
+iframe {
+  width: 360px;
+  height: 100%;
+  border: 2px solid #2c3e50;
+  border-radius: 5px;
 }

--- a/src/main/resources/templates/playing/wait.html
+++ b/src/main/resources/templates/playing/wait.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/出題待機</title>
+  <link rel="stylesheet" href="/css/origin.css" />
+</head>
+
+<body>
+  <div class="container">
+    <div class="display">
+      <h3 th:if="${pgameroom}" th:text="${pgameroom.gameRoomName}"></h3>
+      <div th:if="${participant}">
+        <p>[[${participant.userName}]] さんの</p>
+        <p>現在の順位：[[${participant.rank}]]位</p>
+        <p>現在の得点：[[${participant.point}]]点</p>
+      </div>
+
+      <!--テスト表示用-->
+      <h3>ゲームルーム名</h3>
+      <h2>クイズの出題を待っています</h2>
+      <div>
+        <p>Player さんの</p>
+        <p>現在の順位：1位</p>
+        <p>現在の得点：100点</p>
+      </div>
+    </div>
+
+    <div class="iframe-section">
+      <iframe th:src="@{./ranking}"></iframe>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
Close #56 

開発内容
- templates/playing/wait.html を作成
- PlayingController クラスを作成
  - get_wait() メソッドを定義
- origin.css に iframe-section クラスと iframe タグのスタイルを追加

備考
- iframe 関連のスタイルを含め、wait.html がやや不格好なので、
実際の表示を確認したり、他のページと合わせて調整した方が良い
- DoD では iframe の高さを100vhにするよう指定があるが、iframe-section が乗る container クラスが画面端にスペースを設けているため、100vh にするとページ下方にはみ出す（スクロールになる）。
そのため、一応 container 目一杯の高さで実装している。