### PR TITLE
ゲームルーム主催者開始前ページ(/gameroom/standby)のページの実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
@@ -122,8 +122,9 @@ public class GameroomController {
 
   @GetMapping("/standby")
   public String standby(@RequestParam("room") int roomID, ModelMap model) {
+    model.addAttribute("gameroom", gameroomMapper.selectGameroomByID(roomID));
     PublicGameRoom publicGameRoom = this.pGameRoomManager.getPublicGameRooms().get((long) roomID);
-    model.addAttribute("publicGameroom", publicGameRoom);
+    model.addAttribute("pgameroom", publicGameRoom);
     return "gameroom/standby.html";
   }
 

--- a/src/main/java/oit/is/team7/quiz_7/model/GameRoomParticipant.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/GameRoomParticipant.java
@@ -18,6 +18,10 @@ public class GameRoomParticipant {
     this.userID = userID;
   }
 
+  public String getUserName() {
+    return userName;
+  }
+
   public void setUserName(String userName) {
     this.userName = userName;
   }

--- a/src/main/resources/templates/gameroom/standby.html
+++ b/src/main/resources/templates/gameroom/standby.html
@@ -5,17 +5,35 @@
   <meta charset="utf-8">
   <title>Quiz_7/待機</title>
   <link rel="stylesheet" href="/css/origin.css">
+  <script>
+    function confirmBack(event) {
+      if (!confirm("ゲームルームを中止しますか？")) {
+        event.preventDefault();
+      }
+    }
+  </script>
 </head>
 
 <body>
   <div class="container">
     <div class="display">
       <h3>ゲームルーム情報</h3>
-      <p>ルームID: <span th:text="${publicGameroom.gameRoomID}"></span></p>
+      <p>ルーム名： <span th:text="${gameroom.roomName}"></span></p>
+      <p>ルーム概要： <span th:text="${gameroom.description}"></span></p>
+      <p>参加状況： <span th:text="${#maps.size(pgameroom.participants)}"></span> / <span
+          th:text="${pgameroom.maxPlayers}"></span></p>
+      <h3>参加者リスト</h3>
+      <ul th:if="${pgameroom.participants.values().size() > 0}">
+        <li th:each="participant : ${pgameroom.participants.values()}">
+          <span th:text="${participant.userName}"></span>
+        </li>
+      </ul>
+      <p th:if="${pgameroom.participants.values().size() == 0}">現在参加者はいません。</p>
     </div>
 
-    <div class="input-form">
-      <a href="../gameroom" class="button">戻る</a>
+    <div class="links-section">
+      <a th:href="@{/playing/wait(room=${pgameroom.gameRoomID})}">ゲーム開始</a>
+      <a href="../gameroom" onclick="confirmBack(event)">中止</a>
     </div>
   </div>
 </body>


### PR DESCRIPTION
Close #57 
[概要]
　タスク「ゲームルーム主催者開始前ページ(/gameroom/standby)のページの実装」の実装を行ったPR．

[内容]
- "/standby"へのGETリクエスト処理において，gameroomをmodelに追加．
- standby.htmlで，ルーム名，ルーム概要，参加状況，参加者リストを表示．
- 「ゲーム開始」ボタンを押すと，"/playing/wait"に遷移．
- 「中止」ボタンを押すと，ダイアログボックス上で確認され，OKを選択すると"../gameroom"に遷移．