### PR TITLE
ゲームルーム参加者開始前ページ(/playgame/standby)のページの実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/PlaygameController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlaygameController.java
@@ -56,7 +56,7 @@ public class PlaygameController {
   public String getJoinCheck(@RequestParam("room") long roomID, Principal principal, ModelMap model) {
     PublicGameRoom targetPRoom = this.pGameRoomManager.getPublicGameRooms().get(roomID);
 
-    if(targetPRoom == null) {
+    if (targetPRoom == null) {
       logger.warn("PlaygameController.getJoinCheck(...): PublicGameRoom #%d is null. ", roomID);
     }
 
@@ -64,7 +64,7 @@ public class PlaygameController {
     targetPRoomBean.setHostUserName(targetPRoom.getHostUserName());
     targetPRoomBean.setMaxPlayers(targetPRoom.getMaxPlayers());
 
-    Gameroom targetRoom = gameroomMapper.selectGameroomByID((int)roomID);
+    Gameroom targetRoom = gameroomMapper.selectGameroomByID((int) roomID);
 
     model.addAttribute("pgameroom", targetPRoomBean);
     model.addAttribute("gameroom", targetRoom);
@@ -75,8 +75,9 @@ public class PlaygameController {
   @PostMapping("/join_check")
   public String postJoinCheck(@RequestParam("room") long roomID, Principal principal) {
     // roomIDに対応する公開ゲームルームがない場合(エラー)
-    if(pGameRoomManager.getPublicGameRooms().get(roomID) == null) {
-      logger.warn(String.format("PlaygameController.postJoinCheck(...): Requested NOT exist PublicGameRoom by roomID:%d", roomID));
+    if (pGameRoomManager.getPublicGameRooms().get(roomID) == null) {
+      logger.warn(String
+          .format("PlaygameController.postJoinCheck(...): Requested NOT exist PublicGameRoom by roomID:%d", roomID));
       return "";
     }
 
@@ -88,18 +89,32 @@ public class PlaygameController {
     PublicGameRoom targetPGameRoom = pGameRoomManager.getPublicGameRooms().get(roomID);
 
     targetPGameRoom.getParticipants().put(userID, newParticipant);
-    if(DBG) {
+    if (DBG) {
       PublicGameRoom checkedRoom = pGameRoomManager.getPublicGameRooms().get(roomID);
       GameRoomParticipant subject = checkedRoom.getParticipants().get(userID);
 
-      logger.info(String.format("[DBG] PlaygameController.postJoinCheck(...): Result of put participants(GameRoomParticipant). userID: %d, subject: " + subject, userID));
+      logger.info(String.format(
+          "[DBG] PlaygameController.postJoinCheck(...): Result of put participants(GameRoomParticipant). userID: %d, subject: "
+              + subject,
+          userID));
     }
 
     pGameRoomManager.getBelonging().put(userID, roomID);
-    if(DBG) {
-      logger.info(String.format("[DBG] PlaygameController.postJoinCheck(...): Result of put belonging(gameRoomID(long)). userID: %d, subject: " + pGameRoomManager.getBelonging().get(userID), userID));
+    if (DBG) {
+      logger.info(String.format(
+          "[DBG] PlaygameController.postJoinCheck(...): Result of put belonging(gameRoomID(long)). userID: %d, subject: "
+              + pGameRoomManager.getBelonging().get(userID),
+          userID));
     }
 
-    return "redirect:/playgame/standby";
+    return "redirect:/playgame/standby?room=" + roomID;
+  }
+
+  @GetMapping("/standby")
+  public String standby(@RequestParam("room") int roomID, ModelMap model) {
+    model.addAttribute("gameroom", gameroomMapper.selectGameroomByID(roomID));
+    PublicGameRoom publicGameRoom = this.pGameRoomManager.getPublicGameRooms().get((long) roomID);
+    model.addAttribute("pgameroom", publicGameRoom);
+    return "playgame/standby.html";
   }
 }

--- a/src/main/resources/templates/playgame/standby.html
+++ b/src/main/resources/templates/playgame/standby.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/origin.css">
   <script>
     function confirmBack(event) {
-      if (!confirm("ゲームルームを中止しますか？")) {
+      if (!confirm("ゲームルームを退室しますか？")) {
         event.preventDefault();
       }
     }
@@ -20,6 +20,7 @@
       <h3>ゲームルーム情報</h3>
       <p>ルーム名： <span th:text="${gameroom.roomName}"></span></p>
       <p>ルーム概要： <span th:text="${gameroom.description}"></span></p>
+      <p>ホストユーザ： <span th:text="${pgameroom.hostUserName}"></span></p>
       <p>参加状況： <span th:text="${#maps.size(pgameroom.participants)}"></span> / <span
           th:text="${pgameroom.maxPlayers}"></span></p><br>
       <h3>参加者リスト</h3>
@@ -34,8 +35,7 @@
     </div>
 
     <div class="links-section">
-      <a th:href="@{/playing/wait(room=${pgameroom.gameRoomID})}">ゲーム開始</a>
-      <a href="../gameroom" onclick="confirmBack(event)">中止</a>
+      <a href="../playgame" onclick="confirmBack(event)">退室</a>
     </div>
   </div>
 </body>


### PR DESCRIPTION
Close #58 
[概要]
　タスク「ゲームルーム参加者開始前ページ(/playgame/standby)のページの実装」の実装を行ったPR．

[内容]
- タスク #57 とほぼ同様．
- DoDには無いが，参加者の表示が収まりきらない場合にスクロールバーが表示されるようにした．これに伴って，主催者開始前ページ(/gameroom/standby)にも同様の修正を行った．

[備考]
　現状，画面右半分はlinks-sectionだが，今後各ボタンをaタグではなくformタグに変更することになれば，input-formに修正する予定である．