### PR TITLE
ゲームルーム参加者開始前(待機)ページ(/playgame/standby)でのルーム退室処理の実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/PlaygameController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlaygameController.java
@@ -117,4 +117,11 @@ public class PlaygameController {
     model.addAttribute("pgameroom", publicGameRoom);
     return "playgame/standby.html";
   }
+
+  @PostMapping("/standby/exit")
+  public String exitGameRoom(@RequestParam("room") long roomID, Principal principal) {
+    long userID = userAccountMapper.selectUserAccountByUsername(principal.getName()).getId();
+    pGameRoomManager.removeParticipantFromGameRoom(userID, roomID);
+    return "redirect:/playgame";
+  }
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/PGameRoomManager.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/PGameRoomManager.java
@@ -37,4 +37,12 @@ public class PGameRoomManager {
   public void setBelonging(LinkedHashMap<Long, Long> belonging) {
     this.belonging = belonging;
   }
+
+  public void removeParticipantFromGameRoom(long userID, long roomID) {
+    belonging.remove(userID);
+    PublicGameRoom gameRoom = publicGameRooms.get(roomID);
+    if(gameRoom != null){
+      gameRoom.removeParticipant(userID);
+    }
+  }
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
@@ -57,4 +57,7 @@ public class PublicGameRoom {
     return quizPool;
   }
 
+  public void removeParticipant(long userID) {
+    participants.remove(userID);
+  }
 }

--- a/src/main/resources/templates/playgame/standby.html
+++ b/src/main/resources/templates/playgame/standby.html
@@ -6,10 +6,9 @@
   <title>Quiz_7/待機</title>
   <link rel="stylesheet" href="/css/origin.css">
   <script>
-    function confirmBack(event) {
-      if (!confirm("ゲームルームを退室しますか？")) {
-        event.preventDefault();
-      }
+    function confirmBack() {
+      if (confirm("ゲームルームを退室しますか？"))
+        document.getElementById('exit_room').submit();
     }
   </script>
 </head>
@@ -34,8 +33,9 @@
       </div>
     </div>
 
-    <div class="links-section">
-      <a href="../playgame" onclick="confirmBack(event)">退室</a>
+    <div class="input-form">
+      <form th:action="@{./standby/exit(room=${gameroom.ID})}" method="post" id="exit_room"></form>
+      <button type="button" class="colored_button" onclick="confirmBack();">退室</button>
     </div>
   </div>
 </body>


### PR DESCRIPTION
Close #68 
[概要]
　タスク「ゲームルーム参加者開始前(待機)ページ(/playgame/standby)でのルーム退室処理の実装」の実装を行ったPR．

[内容]
- playgame/standby.html
　- Java Scriptの内容を編集．
　- 退室ボタンをaタグではなく，formタグとbuttonタグで実装．
- PlaygameController.java
　- "/standby/exit"に対するPOSTリクエスト処理であるexitGameRoomメソッド実装．
- PGameRoomManager.java
　- removeParticipantFromGameRoomメソッド実装．
- PublicGameRoom.java
　- removeParticipantメソッド実装．