### PR TITLE
ゲームルーム主催者開始前(待機)ページ(/gameroom/standby)でのゲーム中止処理の実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
@@ -2,6 +2,8 @@ package oit.is.team7.quiz_7.controller;
 
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.LinkedHashMap;
 
 import org.slf4j.Logger;
@@ -126,6 +128,24 @@ public class GameroomController {
     PublicGameRoom publicGameRoom = this.pGameRoomManager.getPublicGameRooms().get((long) roomID);
     model.addAttribute("pgameroom", publicGameRoom);
     return "gameroom/standby.html";
+  }
+
+  @PostMapping("/standby/cancel")
+  public String cancelGameRoom(@RequestParam("room") long roomID, Principal principal) {
+    PublicGameRoom publicGameRoom = this.pGameRoomManager.getPublicGameRooms().get((long) roomID);
+    publicGameRoom.getParticipants().clear();
+    pGameRoomManager.removeGameRoom(roomID);
+    List<Long> usersToBeRemove = new ArrayList<>();
+    for (Map.Entry<Long, Long> entry : pGameRoomManager.getBelonging().entrySet()) {
+      if (entry.getValue() == roomID) {
+        usersToBeRemove.add(entry.getKey());
+      }
+    }
+    for (Long userID : usersToBeRemove) {
+      pGameRoomManager.getBelonging().remove(userID);
+    }
+    gameroomMapper.updatePublishedByID((int) roomID, false);
+    return "redirect:/gameroom";
   }
 
   @GetMapping("/delete")

--- a/src/main/java/oit/is/team7/quiz_7/model/PGameRoomManager.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/PGameRoomManager.java
@@ -38,6 +38,10 @@ public class PGameRoomManager {
     this.belonging = belonging;
   }
 
+  public void removeGameRoom(long roomID) {
+    publicGameRooms.remove(roomID);
+  }
+
   public void removeParticipantFromGameRoom(long userID, long roomID) {
     belonging.remove(userID);
     PublicGameRoom gameRoom = publicGameRooms.get(roomID);

--- a/src/main/resources/templates/gameroom/standby.html
+++ b/src/main/resources/templates/gameroom/standby.html
@@ -6,9 +6,9 @@
   <title>Quiz_7/待機</title>
   <link rel="stylesheet" href="/css/origin.css">
   <script>
-    function confirmBack(event) {
-      if (!confirm("ゲームルームを中止しますか？")) {
-        event.preventDefault();
+    function confirmBack() {
+      if (confirm("ゲームルームを中止しますか？")) {
+        document.getElementById('cancel_room').submit();
       }
     }
   </script>
@@ -33,9 +33,11 @@
       </div>
     </div>
 
-    <div class="links-section">
-      <a th:href="@{/playing/wait(room=${pgameroom.gameRoomID})}">ゲーム開始</a>
-      <a href="../gameroom" onclick="confirmBack(event)">中止</a>
+    <div class="input-form">
+      <a th:href="@{/playing/wait(room=${pgameroom.gameRoomID})}" class="colored_button"
+        style="margin-bottom: 20px;">ゲーム開始</a>
+      <form th:action="@{./standby/cancel(room=${gameroom.ID})}" method="post" id="cancel_room"></form>
+      <button type="button" class="colored_button" onclick="confirmBack();" style="margin-top: 20px;">中止</button>
     </div>
   </div>
 </body>


### PR DESCRIPTION
Close #67 
[概要]
　タスク「ゲームルーム主催者開始前(待機)ページ(/gameroom/standby)でのゲーム中止処理の実装」の実装を行ったPR．

[内容]
- gameroom/standby.html
　- Java Scriptの内容を編集．
　- 中止ボタンをaタグではなく，formタグとbuttonタグで実装．
- GameroomController.java
　- "/standby/cancel"に対するPOSTリクエスト処理であるcancelGameRoomメソッド実装．
- PGameRoomManager.java
　- removeGameRoomメソッド実装．

[備考]
　SSE実装後，閉じられたルームに参加していたユーザの画面に「ルームが閉じられた」ことを示す文言を表示するとともに，参加ゲームルーム選択ページ(/playgame)に遷移させるようなタスクを実施する必要がある．
　現状，ホスト側でルームを閉じた後，参加者が待機画面をリロードするとエラー画面になるが，これは正常にルーム情報が削除された結果である．