### PR TITLE
[参加者]出題待機ページ(/playing/wait)のルームIDによる表示の実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -2,6 +2,8 @@ package oit.is.team7.quiz_7.controller;
 
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,11 +17,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ch.qos.logback.classic.Logger;
+import oit.is.team7.quiz_7.model.GameRoomParticipant;
 import oit.is.team7.quiz_7.model.PGameRoomManager;
 import oit.is.team7.quiz_7.model.PublicGameRoom;
 import oit.is.team7.quiz_7.model.QuizJson;
 import oit.is.team7.quiz_7.model.QuizTable;
 import oit.is.team7.quiz_7.model.QuizTableMapper;
+import oit.is.team7.quiz_7.model.UserAccountMapper;
 import oit.is.team7.quiz_7.utils.JsonUtils;
 
 @Controller
@@ -33,18 +37,36 @@ public class PlayingController {
   @Autowired
   QuizTableMapper quizTableMapper;
 
-  public String get_wait_guest(Principal prin, ModelMap model) {
+  @Autowired
+  UserAccountMapper userAccountMapper;
+
+  public String get_wait_guest(int roomID, Principal prin, ModelMap model) {
+    long userID = userAccountMapper.selectUserAccountByUsername(prin.getName()).getId();
+    Map<Long, GameRoomParticipant> participants = this.pGameRoomManager.getPublicGameRooms().get((long) roomID)
+        .getParticipants();
+    GameRoomParticipant participant = participants.get(userID);
+    if (participant != null) {
+      model.addAttribute("participant", participant);
+    }
+    List<GameRoomParticipant> sortParticipants = new ArrayList<>(participants.values());
+    sortParticipants.sort((p1, p2) -> Long.compare(p2.getPoint(), p1.getPoint()));
+    for (int rank = 0; rank < sortParticipants.size(); rank++) {
+      GameRoomParticipant target = sortParticipants.get(rank);
+      if (target.getUserID() == userID) {
+        model.addAttribute("participant_rank", rank + 1);
+      }
+    }
     return "/playing/guest/wait.html";
   }
 
   @GetMapping("/wait")
   public String get_wait_host(@RequestParam("room") int roomID, Principal prin, ModelMap model) {
     PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get((long) roomID);
+    model.addAttribute("pgameroom", pgroom);
     if (!pgroom.getHostUserName().equals(prin.getName())) {
       // ユーザがホストでなければゲスト向けの待機画面を表示
-      return get_wait_guest(prin, model);
+      return get_wait_guest(roomID, prin, model);
     }
-    model.addAttribute("pgameroom", pgroom);
     ArrayList<QuizTable> quizList = new ArrayList<QuizTable>();
     for (long quizID : pgroom.getQuizPool()) {
       quizList.add(quizTableMapper.selectQuizTableByID((int) quizID));

--- a/src/main/java/oit/is/team7/quiz_7/model/GameRoomParticipant.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/GameRoomParticipant.java
@@ -2,8 +2,8 @@ package oit.is.team7.quiz_7.model;
 
 /**
  * @classdesc
- * 単一のゲームルームの参加者を成すクラス．
- * 詳しくは本サービスの最新のクラス設計図(quiz_7_ClassGraph_Isdev24_ver*.drawio)を参照．
+ *            単一のゲームルームの参加者を成すクラス．
+ *            詳しくは本サービスの最新のクラス設計図(quiz_7_ClassGraph_Isdev24_ver*.drawio)を参照．
  *
  */
 public class GameRoomParticipant {
@@ -18,11 +18,19 @@ public class GameRoomParticipant {
     this.userID = userID;
   }
 
+  public long getUserID() {
+    return userID;
+  }
+
   public String getUserName() {
     return userName;
   }
 
   public void setUserName(String userName) {
     this.userName = userName;
+  }
+
+  public long getPoint() {
+    return point;
   }
 }

--- a/src/main/resources/templates/playing/guest/wait.html
+++ b/src/main/resources/templates/playing/guest/wait.html
@@ -11,19 +11,11 @@
   <div class="container">
     <div class="display">
       <h3 th:if="${pgameroom}" th:text="${pgameroom.gameRoomName}"></h3>
+      <h2>クイズの出題を待っています</h2>
       <div th:if="${participant}">
         <p>[[${participant.userName}]] さんの</p>
-        <p>現在の順位：[[${participant.rank}]]位</p>
+        <p>現在の順位：[[${participant_rank}]]位</p>
         <p>現在の得点：[[${participant.point}]]点</p>
-      </div>
-
-      <!--テスト表示用-->
-      <h3>ゲームルーム名</h3>
-      <h2>クイズの出題を待っています</h2>
-      <div>
-        <p>Player さんの</p>
-        <p>現在の順位：1位</p>
-        <p>現在の得点：100点</p>
       </div>
     </div>
 


### PR DESCRIPTION
Close #63 
[概要]
　タスク「[参加者]出題待機ページ(/playing/wait)のルームIDによる表示の実装」の実装を行ったPR．

[内容]
- playing/guest/wait.html
　- テストユーザ情報の削除．
　- ログイン中のユーザが参加したルームの名前を表示．
　- ログイン中のユーザの名前，順位，得点を表示．
- PlayingController.java
　- "/wait"に対するGETリクエスト処理中に分岐で実行されるget_wait_guestメソッド実装．
　- 順位に関しては，GameRoomParticipantにフィールドが存在しないため，ここで都度ソートして求めているが，今後の実装によっては簡略化できるかもしれない．

[DoD確認手順]
1. ユーザ1でログインしてルーム公開
2. ユーザ2でログインして公開されたルームに参加
3. ユーザ2側でURLを”/playing/wait?room=(該当roomID)”に変更
4. 参加ルーム名，ユーザ2の名前，順位，得点の表示を確認
5. ユーザ3，4...以降も同様．得点は全員0点だが，順位は入室順になっている．