### PR TITLE
ゲームルーム主催者開始前(待機)ページ(/gameroom/standby)の「ゲーム開始」処理の実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/model/GameRoomParticipant.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/GameRoomParticipant.java
@@ -33,4 +33,11 @@ public class GameRoomParticipant {
   public long getPoint() {
     return point;
   }
+
+  public void resetForNewGame() {
+    this.point = 0L;
+    this.answered = false;
+    this.answerTime = 0.0;
+    this.answerContent = null;
+  }
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
@@ -87,4 +87,10 @@ public class PublicGameRoom {
     this.open = open;
   }
 
+  public void resetAllParticipants() {
+    for (GameRoomParticipant participant : participants.values()) {
+      participant.resetForNewGame();
+    }
+  }
+
 }


### PR DESCRIPTION
Close #85 
[概要]
　タスク「ゲームルーム主催者開始前(待機)ページ(/gameroom/standby)の「ゲーム開始」処理の実装」を行ったPR．

[内容]
- PlayingController.java
　- "/wait"に対するGETリクエスト処理内で参加者情報の初期化を実行．
- PublicGameRoom.java
　- resetAllParticipantsメソッド実装．
- GameRoomParticipant.java
　- resetForNewGameメソッド実装．

[備考]
　動作によるDoDの確認は難しいため，実装内容で判断してもらいたい．一応，初期化処理時には「〇人の初期化を完了」といったログを表示している．