### PR TITLE
[参加者]最終結果表示ページ(/playing/overall)のページの実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -99,6 +99,40 @@ public class PlayingController {
     return "/playing/host/wait.html";
   }
 
+  @GetMapping("/overall")
+  public String get_overall_host(@RequestParam("room") int roomID, Principal prin, ModelMap model) {
+    PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get((long) roomID);
+    if (!pgroom.getHostUserName().equals(prin.getName())) {
+      // ユーザがホストでなければゲスト向けの待機画面を表示
+      model.addAttribute("pgameroom", pgroom);
+      return get_overall_guest(roomID, prin, model);
+    }
+    model.addAttribute("pgameroom", pgroom);
+    return "/playing/host/overall.html";
+  }
+
+  public String get_overall_guest(@RequestParam("room") int roomID, Principal prin, ModelMap model) {
+    long userID = userAccountMapper.selectUserAccountByUsername(prin.getName()).getId();
+    PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get((long) roomID);
+    Map<Long, GameRoomParticipant> participants = pgroom.getParticipants();
+    GameRoomParticipant participant = participants.get(userID);
+    if (pgroom != null) {
+      model.addAttribute("pgameroom", pgroom);
+    }
+    if (participant != null) {
+      model.addAttribute("participant", participant);
+    }
+    List<GameRoomParticipant> sortParticipants = new ArrayList<>(participants.values());
+    sortParticipants.sort((p1, p2) -> Long.compare(p2.getPoint(), p1.getPoint()));
+    for (int rank = 0; rank < sortParticipants.size(); rank++) {
+      GameRoomParticipant target = sortParticipants.get(rank);
+      if (target.getUserID() == userID) {
+        model.addAttribute("participantRank", rank + 1);
+      }
+    }
+    return "/playing/guest/overall.html";
+  }
+
   @GetMapping("/ranking")
   public String getRanking(@RequestParam(name = "room", required = false) Long roomID,
       @RequestParam(name = "user", required = false) Long userID,

--- a/src/main/java/oit/is/team7/quiz_7/model/PGameRoomRanking.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/PGameRoomRanking.java
@@ -29,9 +29,9 @@ public class PGameRoomRanking {
     final int INVALID_IDX = -1;
     int idx = (this.indexByUserID.get(entry.ID) != null ? this.indexByUserID.get(entry.ID) : INVALID_IDX);
 
-    if(idx == INVALID_IDX) {
+    if (idx == INVALID_IDX) {
       this.ranking.add(entry);
-      this.indexByUserID.put(entry.ID, this.ranking.size()-1);
+      this.indexByUserID.put(entry.ID, this.ranking.size() - 1);
     } else {
       this.ranking.set(idx, entry);
     }
@@ -42,8 +42,9 @@ public class PGameRoomRanking {
   }
 
   public ArrayList<PGameRoomRankingEntryBean> getRanking() {
-    if(this.sortState == SortState.NON_SORTED) {
-      throw new IllegalStateException("ソートされていないランキングの参照は許可されていません．");
+    if (this.sortState == SortState.NON_SORTED) {
+      // throw new IllegalStateException("ソートされていないランキングの参照は許可されていません．");
+      this.sortByPoint();
     }
 
     return new ArrayList<PGameRoomRankingEntryBean>(this.ranking);
@@ -62,11 +63,11 @@ public class PGameRoomRanking {
 
   public void sortByPoint() {
     // [エラー] ランキングのエントリがない場合．
-    if(this.ranking.size() <= 0) {
+    if (this.ranking.size() <= 0) {
       throw new IllegalStateException("ランキングのエントリがない状態での並べ替えは許可されていません．");
     }
 
-    if(this.sortState == SortState.SORTED_ON_POINT) {
+    if (this.sortState == SortState.SORTED_ON_POINT) {
       return;
     }
 
@@ -79,7 +80,7 @@ public class PGameRoomRanking {
     });
 
     // インデックスのMapを再定義．
-    for(int i = 0; i < this.ranking.size(); i++) {
+    for (int i = 0; i < this.ranking.size(); i++) {
       this.indexByUserID.put(this.ranking.get(i).ID, i);
     }
 
@@ -87,11 +88,11 @@ public class PGameRoomRanking {
     long seePt = this.ranking.get(0).point;
 
     // 順位付け
-    for(int i = 0; i < this.ranking.size(); i++) {
-      if(seePt == this.ranking.get(i).point) {
+    for (int i = 0; i < this.ranking.size(); i++) {
+      if (seePt == this.ranking.get(i).point) {
         this.ranking.get(i).updateRank(rank);
       } else {
-        rank = (i+1);
+        rank = (i + 1);
         this.ranking.get(i).updateRank(rank);
         seePt = this.ranking.get(i).point;
       }

--- a/src/main/resources/templates/playing/guest/overall.html
+++ b/src/main/resources/templates/playing/guest/overall.html
@@ -16,6 +16,7 @@
         <p>最終順位：[[${participantRank}]]位</p>
         <p>最終得点：[[${participant.point}]]点</p>
       </div>
+      <a th:href="@{/main}">メインページ</a>
     </div>
 
     <div class="iframe-section">

--- a/src/main/resources/templates/playing/guest/overall.html
+++ b/src/main/resources/templates/playing/guest/overall.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/最終結果</title>
+  <link rel="stylesheet" href="/css/origin.css" />
+</head>
+
+<body>
+  <div class="container">
+    <div class="display">
+      <h3 th:if="${pgameroom}" th:text="${pgameroom.gameRoomName}"></h3>
+      <div th:if="${participant}">
+        <p>[[${participant.userName}]] さんの</p>
+        <p>最終順位：[[${participantRank}]]位</p>
+        <p>最終得点：[[${participant.point}]]点</p>
+      </div>
+    </div>
+
+    <div class="iframe-section">
+      <iframe th:src="@{./ranking}"></iframe>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
Close #62 

開発内容
- PlayingController に get_overall_host(), get_overall_guest() を実装
  - get_overall_host() は形式のみで無意味
  - 参加者の順位については PublicGameRoom クラスの ranking を利用するべきと思ったが、
  使い方がよくわからなかったので get_wait_guest() と同様の手法でマッピングした。
- /playing/guest/overall.html を作成
  - iframe のランキング表示を利用している
  - ルームの参加者として 「/playing/overall?room=（参加しているルームのID）」にアクセスすれば表示される

備考
- PublicGameRoom クラスの getRanking() でランキングを参加者と順位の Map などの扱いやすい形で返すようにして、PGameRoomRanking クラスを触らなくてもルームのランキングや参加者の順位が参照できるようにして欲しい