### PR TITLE
[参加者]解答ページ(/playing/answer)へのSSE強制遷移機能の実装 の完了

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/SseController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/SseController.java
@@ -1,5 +1,7 @@
 package oit.is.team7.quiz_7.controller;
 
+import java.security.Principal;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import oit.is.team7.quiz_7.model.UserAccountMapper;
 import oit.is.team7.quiz_7.model.PGameRoomManager;
 import oit.is.team7.quiz_7.model.PublicGameRoom;
 import oit.is.team7.quiz_7.service.AsyncPGameRoomService;
@@ -22,6 +25,9 @@ public class SseController {
 
   @Autowired
   PGameRoomManager pGameRoomManager;
+
+  @Autowired
+  UserAccountMapper userAccountMapper;
 
   // 参加者リストを取得するエンドポイント
   @GetMapping("/participantsList")
@@ -71,4 +77,17 @@ public class SseController {
     return emitter;
   }
 
+  // 解答ページ(/playing/answer)に強制遷移させるエンドポイント
+  @GetMapping("/transitToAnswer")
+  public SseEmitter transitToAnswer(Principal prin) {
+    logger.info("SseController.transitToAnswer is called by user '" + prin.getName() + "'. ");
+
+    final SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+    long userID = userAccountMapper.selectUserAccountByUsername(prin.getName()).getId();
+    long roomID = pGameRoomManager.getBelonging().get(userID);
+
+    asyncPGRService.asyncAutoRedirectToAnswerPage(emitter, roomID);
+
+    return emitter;
+  }
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
@@ -27,6 +27,7 @@ public class PublicGameRoom {
   private PGameRoomRanking ranking;
   private int nextQuizIndex;
   private boolean open;
+  private boolean answering;
 
   @Autowired
   AsyncPGameRoomService asyncPGRService;
@@ -44,6 +45,7 @@ public class PublicGameRoom {
     this.ranking = new PGameRoomRanking();
     this.nextQuizIndex = 0;
     this.open = true;
+    this.answering = false;
   }
 
   public long getGameRoomID() {
@@ -141,7 +143,7 @@ public class PublicGameRoom {
   public void removeEmitter(SseEmitter emitter) {
     emitters.remove(emitter);
   }
-  
+
     public boolean isOpen() {
     return open;
   }
@@ -156,4 +158,15 @@ public class PublicGameRoom {
     }
   }
 
+  public boolean isAnswering() {
+    return this.answering;
+  }
+
+  public void startAnswer() {
+    this.answering = true;
+  }
+
+  public void endAnswer() {
+    this.answering = false;
+  }
 }

--- a/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
+++ b/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
@@ -121,4 +121,27 @@ public class AsyncPGameRoomService {
       pageTransitionMap.put(roomID, true);
     }
   }
+
+  @Async
+  public void asyncAutoRedirectToAnswerPage(SseEmitter emitter, long roomID) {
+    logger.info("AsyncPGameRoomService.asyncAutoRedirectToAnswerPage is called with roomID: " + roomID);
+
+    try {
+      PublicGameRoom redirectToRoom =  pGameRoomManager.getPublicGameRooms().get(roomID);
+
+      emitter.send(SseEmitter.event().name("init").data("SSE connection established. Ready to auto-redirect to Answer Page of roomID: " + roomID));
+      while(true) {
+        if(redirectToRoom.isAnswering()) {
+          emitter.send(roomID);
+          break;
+        }
+
+        TimeUnit.MILLISECONDS.sleep(100L);
+      }
+    } catch(Exception e) {
+      logger.error("AsyncPGameRoomService.asyncAutoRedirectToAnswerPage Error: " + e.getClass().getName() + ":" + e.getMessage());
+    } finally {
+      emitter.complete();
+    }
+  }
 }

--- a/src/main/resources/static/js/SseAutoRedirectToAnswerPage.js
+++ b/src/main/resources/static/js/SseAutoRedirectToAnswerPage.js
@@ -1,0 +1,28 @@
+function SseAutoRedirectToAnswerPage() {
+  console.log("SseAutoRedirectToAnswerPage function is called. ")
+
+  let sse = new EventSource("/sse/transitToAnswer");
+  sse.onopen = function() {
+    console.info("SseAutoRedirectToAnserPage: SSE connection opened. ");
+  };
+  sse.onerror = function (error) {
+    console.error("SseAutoRedirectToAnserPage: SSE error: ", error);
+  };
+  sse.addEventListener('init', function (event) {
+    console.log("SseAutoRedirectToAnserPage: Init event received: " + event.data);
+  });
+  sse.onmessage = function(event) {
+    console.log("SseAutoRedirectToAnserPage: sse.onmessage Event received: " + event.data);
+
+    try {
+      if(!isNaN(event.data)) {
+        const loc = "/playing/answer?room=" + event.data;
+        console.log("Redirect to " + loc);
+        window.location.href = loc;
+      }
+
+    } catch(e) {
+      console.error("Error by " + e);
+    }
+  };
+}

--- a/src/main/resources/templates/playing/guest/wait.html
+++ b/src/main/resources/templates/playing/guest/wait.html
@@ -5,6 +5,12 @@
   <meta charset="utf-8">
   <title>Quiz_7/出題待機</title>
   <link rel="stylesheet" href="/css/origin.css" />
+  <script src="/js/SseAutoRedirectToAnswerPage.js"></script>
+  <script>
+    window.onload = function() {
+      SseAutoRedirectToAnswerPage();
+    };
+  </script>
 </head>
 
 <body>


### PR DESCRIPTION
### [概要]
　タスク「[参加者]解答ページ(/playing/answer)へのSSE強制遷移機能の実装」(#64) の実装を行ったPR．
　タスク詳細は対応するIssueを確認してもらいたい．

### [レビュアー]
- e1b22103

### [DoD]
　※PRと同名のIssueに記載済みなので省略．

### [重要事項]
　このタスクおよびDoDは明確な動作を確認できるものではなく，正直後の実装になって確認できるものであるため，実装内容そのもののレビューしかできないと思います．加えて，既存のサービスの実装・動作に一切の影響がないはずなので，そのままマージしてもらっても良いと思います．(たぶんあまりよくないけど)
　実装部分へのコメントアウトは要請あれば行うものとします．

### [実行/実装事項]
　(省略，PRのFiles changedを参照されたい)
　実装内容は余力あれば記載する．もしくは，要請あれば記載する．

### [以降の開発についてのメモ]
　(なし)

### [備考]
　(なし)
