### PR TITLE
参加者に対する公開ゲームルーム中止表示・初期画面遷移の処理の実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
@@ -31,6 +31,7 @@ import oit.is.team7.quiz_7.model.QuizJson;
 import oit.is.team7.quiz_7.model.QuizTable;
 import oit.is.team7.quiz_7.model.QuizTableMapper;
 import oit.is.team7.quiz_7.model.UserAccountMapper;
+import oit.is.team7.quiz_7.service.AsyncPGameRoomService;
 
 @Controller
 @RequestMapping("/gameroom")
@@ -50,6 +51,9 @@ public class GameroomController {
 
   @Autowired
   PGameRoomManager pGameRoomManager;
+
+  @Autowired
+  AsyncPGameRoomService asyncPGRService;
 
   @GetMapping
   public String gameroom(Principal principal, ModelMap model) {
@@ -132,6 +136,7 @@ public class GameroomController {
 
   @PostMapping("/standby/cancel")
   public String cancelGameRoom(@RequestParam("room") long roomID, Principal principal) {
+    asyncPGRService.cancelGameRoom(roomID);
     PublicGameRoom publicGameRoom = this.pGameRoomManager.getPublicGameRooms().get((long) roomID);
     publicGameRoom.getParticipants().clear();
     pGameRoomManager.removeGameRoom(roomID);

--- a/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
+++ b/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
@@ -121,4 +121,25 @@ public class AsyncPGameRoomService {
       pageTransitionMap.put(roomID, true);
     }
   }
+
+  public void cancelGameRoom(long roomID) {
+    logger.info("cancelGameRoom called with roomID: " + roomID);
+    PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get(roomID);
+    if (pgroom != null) {
+      notifyCancellation(pgroom);
+    }
+  }
+
+  @Async
+  public void notifyCancellation(PublicGameRoom pgroom) {
+    logger.info("notifyCancellation called with roomID: " + pgroom.getGameRoomID());
+    for (SseEmitter emitter : pgroom.getEmitters()) {
+      try {
+        emitter.send(SseEmitter.event().name("gameCancelled").data("gameCancelled"));
+      } catch (Exception e) {
+        pgroom.removeEmitter(emitter);
+      }
+    }
+  }
+
 }

--- a/src/main/resources/static/js/SseGetParticipantsList.js
+++ b/src/main/resources/static/js/SseGetParticipantsList.js
@@ -60,24 +60,6 @@ window.onload = function () {
       console.log("Error parsing event data:", e);
     }
   });
-  // SSEpageTransition.addEventListener('gameCancelled', function (event) {
-  //   console.log("Event received:" + event.data);
-  //   try {
-  //     if (event.data == "gameCancelled") {
-  //       var isHost = document.body.getAttribute('data-is-host');
-  //       console.log("isHost value:", isHost);
-  //       if (isHost === 'false') {
-  //         console.log("Confirm dialog will appear.");
-  //         if (confirm("ホストによりゲームが中止されました。")) {
-  //           console.log("Page transition detected");
-  //           window.location.href = "/playgame";
-  //         }
-  //       }
-  //     }
-  //   } catch (e) {
-  //     console.log("Error parsing event data:", e);
-  //   }
-  // });
   SSEpageTransition.addEventListener('init', function (event) {
     console.log("Init event received: " + event.data);
   });

--- a/src/main/resources/static/js/SseGetParticipantsList.js
+++ b/src/main/resources/static/js/SseGetParticipantsList.js
@@ -60,10 +60,45 @@ window.onload = function () {
       console.log("Error parsing event data:", e);
     }
   });
+  // SSEpageTransition.addEventListener('gameCancelled', function (event) {
+  //   console.log("Event received:" + event.data);
+  //   try {
+  //     if (event.data == "gameCancelled") {
+  //       var isHost = document.body.getAttribute('data-is-host');
+  //       console.log("isHost value:", isHost);
+  //       if (isHost === 'false') {
+  //         console.log("Confirm dialog will appear.");
+  //         if (confirm("ホストによりゲームが中止されました。")) {
+  //           console.log("Page transition detected");
+  //           window.location.href = "/playgame";
+  //         }
+  //       }
+  //     }
+  //   } catch (e) {
+  //     console.log("Error parsing event data:", e);
+  //   }
+  // });
   SSEpageTransition.addEventListener('init', function (event) {
     console.log("Init event received: " + event.data);
   });
   SSEpageTransition.onerror = function (error) {
     console.log("SSE error:", error);
   }
+
+  function showModal() {
+    var modal = document.getElementById("modal");
+    modal.style.display = "flex";
+  }
+
+  // モーダルを閉じる処理
+  document.getElementById("confirmButton").addEventListener("click", function () {
+    window.location.href = "/playgame";
+  });
+
+  // SSEイベントを受け取ったときにモーダルを表示
+  SSEpageTransition.addEventListener('gameCancelled', function (event) {
+    if (event.data == "gameCancelled") {
+      showModal();
+    }
+  });
 }

--- a/src/main/resources/templates/gameroom/standby.html
+++ b/src/main/resources/templates/gameroom/standby.html
@@ -16,7 +16,7 @@
   </script>
 </head>
 
-<body data-is-host="true">
+<body>
   <div class="container">
     <div class="display">
       <h3>ゲームルーム情報</h3>

--- a/src/main/resources/templates/gameroom/standby.html
+++ b/src/main/resources/templates/gameroom/standby.html
@@ -16,7 +16,7 @@
   </script>
 </head>
 
-<body>
+<body data-is-host="true">
   <div class="container">
     <div class="display">
       <h3>ゲームルーム情報</h3>

--- a/src/main/resources/templates/playgame/standby.html
+++ b/src/main/resources/templates/playgame/standby.html
@@ -12,9 +12,28 @@
         document.getElementById('exit_room').submit();
     }
   </script>
+  <style>
+    .modal {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0, 0, 0, 0.5);
+      justify-content: center;
+      align-items: center;
+    }
+
+    .modal-content {
+      background-color: white;
+      padding: 20px;
+      border-radius: 5px;
+    }
+  </style>
 </head>
 
-<body>
+<body data-is-host="false">
   <div class="container">
     <div class="display">
       <h3>ゲームルーム情報</h3>
@@ -39,6 +58,13 @@
     <div class="input-form">
       <form th:action="@{./standby/exit(room=${gameroom.ID})}" method="post" id="exit_room"></form>
       <button type="button" class="colored_button" onclick="confirmBack();">退室</button>
+    </div>
+  </div>
+
+  <div id="modal" class="modal">
+    <div class="modal-content">
+      <p>ホストによりゲームが中止されました。</p>
+      <button id="confirmButton">OK</button>
     </div>
   </div>
 </body>

--- a/src/main/resources/templates/playgame/standby.html
+++ b/src/main/resources/templates/playgame/standby.html
@@ -33,7 +33,7 @@
   </style>
 </head>
 
-<body data-is-host="false">
+<body>
   <div class="container">
     <div class="display">
       <h3>ゲームルーム情報</h3>


### PR DESCRIPTION
Close #84 
[概要]
　タスク「参加者に対する公開ゲームルーム中止表示・初期画面遷移の処理の実装」を行ったPR．

[内容]
- AsyncPGameRoomService.java
　- cancelGameRoomメソッド，notifyCancellationメソッドを実装．
- GameroomController.java
　- 実装したcancelGameRoomメソッドを"/standby/cancel"に対するPOSTリクエスト処理内で実行．
- playgame/standby.html
　- 「ホストがルームを中止した」といった文言を表示するウィンドウを実装．
- SseGetParticipantsList.js
　- htmlで実装したウィンドウの表示・削除処理や，画面遷移処理を実装． 

[備考]
　SSE自信ないので，レビュー時に細かく確認してもらいたいです．
　htmlに追加したウィンドウのstyleについては，とりあえずheadに記述しています．
　任意DoDに関しては前々回の会議より，「想定外の操作」であるとし，今回は実装していない．