### PR TITLE
[参加者]解答ページ(/playing/answer)へのSSE強制遷移機能の実装, クイズ出題処理の実装 の完了

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -2,6 +2,7 @@ package oit.is.team7.quiz_7.controller;
 
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -31,6 +32,9 @@ import oit.is.team7.quiz_7.model.QuizTableMapper;
 import oit.is.team7.quiz_7.model.UserAccountMapper;
 import oit.is.team7.quiz_7.service.AsyncPGameRoomService;
 import oit.is.team7.quiz_7.utils.JsonUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
 
 @Controller
 @RequestMapping("/playing")
@@ -198,5 +202,48 @@ public class PlayingController {
 
     // リクエストパラメータが全て正常に指定されている場合，ユーザを軸にしたランキングを表示．
     return RETURN_TEMPLATE;
+  }
+
+  @GetMapping("/start_quiz")
+  public String postStartQuiz(@RequestParam("room") final long roomID, @RequestParam(name = "DBG", defaultValue = "false") final Boolean DBG_FLAG, Principal prin) {
+    long userID = userAccountMapper.selectUserAccountByUsername(prin.getName()).getId();
+    PublicGameRoom targetGameRoom = pGameRoomManager.getPublicGameRooms().get(roomID);
+
+    // [エラー] 該当する公開ゲームルームがない場合
+    if(targetGameRoom == null) {
+      return "/error";
+    }
+
+    // [エラー] リクエストしてきたユーザがホストではない場合
+    if(targetGameRoom.getHostUserID() != userID) {
+      return "/error";
+    }
+
+    targetGameRoom.setStartedAnswerAt_msNow();
+    targetGameRoom.startAnswer();
+    targetGameRoom.unconfirmResult();
+
+    for(final Map.Entry<Long, GameRoomParticipant> entry : targetGameRoom.getParticipants().entrySet()) {
+      GameRoomParticipant participant = targetGameRoom.getParticipants().get(entry.getKey());
+
+      participant.resetAnswer();
+    }
+
+    // デバッグ用
+    if(DBG_FLAG) {
+      StringBuilder logSB = new StringBuilder();
+      logSB.append("Start Quiz at roomID: " + roomID + "\n");
+      logSB.append("Now System.currentTimeMillis(): " + System.currentTimeMillis() + "\n");
+      logSB.append("targetGameRoom.startedAnswerAt_ms(): " + targetGameRoom.getStartedAnswerAt_ms() + "\n");
+      logSB.append("targetGameRoom.isAnswering(): " + targetGameRoom.isAnswering() + "\n");
+      logSB.append("targetGameRoom.isConfirmedResult(): " + targetGameRoom.isConfirmedResult() + "\n");
+      for(final Map.Entry<Long, GameRoomParticipant> entry : targetGameRoom.getParticipants().entrySet()) {
+        GameRoomParticipant participant = targetGameRoom.getParticipants().get(entry.getKey());
+        logSB.append("participant(ID: " + entry.getKey() + "): { " + "isAnswered(): " + participant.isAnswered() + ", getAnswerTime(): " + participant.getAnswerTime() + ", getAnswerContent(): " + participant.getAnswerContent() + " }" + "\n");
+      }
+      logger.info(logSB.toString());
+    }
+
+    return "redirect:/playing/ans_result";
   }
 }

--- a/src/main/java/oit/is/team7/quiz_7/controller/SseController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/SseController.java
@@ -1,5 +1,7 @@
 package oit.is.team7.quiz_7.controller;
 
+import java.security.Principal;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import oit.is.team7.quiz_7.model.UserAccountMapper;
 import oit.is.team7.quiz_7.model.PGameRoomManager;
 import oit.is.team7.quiz_7.model.PublicGameRoom;
 import oit.is.team7.quiz_7.service.AsyncPGameRoomService;
@@ -22,6 +25,9 @@ public class SseController {
 
   @Autowired
   PGameRoomManager pGameRoomManager;
+
+  @Autowired
+  UserAccountMapper userAccountMapper;
 
   // 参加者リストを取得するエンドポイント
   @GetMapping("/participantsList")
@@ -71,4 +77,17 @@ public class SseController {
     return emitter;
   }
 
+  // 解答ページ(/playing/answer)に強制遷移させるエンドポイント
+  @GetMapping("/transitToAnswer")
+  public SseEmitter transitToAnswer(Principal prin) {
+    logger.info("SseController.transitToAnswer is called by user '" + prin.getName() + "'. ");
+
+    final SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+    long userID = userAccountMapper.selectUserAccountByUsername(prin.getName()).getId();
+    long roomID = pGameRoomManager.getBelonging().get(userID);
+
+    asyncPGRService.asyncAutoRedirectToAnswerPage(emitter, roomID);
+
+    return emitter;
+  }
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/GameRoomParticipant.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/GameRoomParticipant.java
@@ -11,7 +11,7 @@ public class GameRoomParticipant {
   private String userName;
   private long point = 0L;
   private boolean answered;
-  private double answerTime;
+  private long answerTime;
   private AnswerObj answerContent;
 
   public long getUserID() {
@@ -33,7 +33,7 @@ public class GameRoomParticipant {
   public long getPoint() {
     return point;
   }
-  
+
   public void setPoint(long point) {
     this.point = point;
   }
@@ -46,11 +46,11 @@ public class GameRoomParticipant {
     this.answered = answered;
   }
 
-  public double getAnswerTime() {
+  public long getAnswerTime() {
     return answerTime;
   }
 
-  public void setAnswerTime(double answerTime) {
+  public void setAnswerTime(long answerTime) {
     this.answerTime = answerTime;
   }
 
@@ -61,12 +61,17 @@ public class GameRoomParticipant {
   public void setAnswerContent(AnswerObj answerContent) {
     this.answerContent = answerContent;
   }
-  
+
    public void resetForNewGame() {
     this.point = 0L;
     this.answered = false;
-    this.answerTime = 0.0;
+    this.answerTime = 0L;
     this.answerContent = null;
   }
 
+  public void resetAnswer() {
+    this.answered = false;
+    this.answerTime = 0L;
+    this.answerContent = null;
+  }
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
@@ -27,6 +27,9 @@ public class PublicGameRoom {
   private PGameRoomRanking ranking;
   private int nextQuizIndex;
   private boolean open;
+  private long startedAnswerAt_ms;
+  private boolean answering;
+  private boolean confirmedResult;
 
   @Autowired
   AsyncPGameRoomService asyncPGRService;
@@ -44,6 +47,8 @@ public class PublicGameRoom {
     this.ranking = new PGameRoomRanking();
     this.nextQuizIndex = 0;
     this.open = true;
+    this.startedAnswerAt_ms = System.currentTimeMillis();
+    this.answering = false;
   }
 
   public long getGameRoomID() {
@@ -141,7 +146,7 @@ public class PublicGameRoom {
   public void removeEmitter(SseEmitter emitter) {
     emitters.remove(emitter);
   }
-  
+
     public boolean isOpen() {
     return open;
   }
@@ -156,4 +161,39 @@ public class PublicGameRoom {
     }
   }
 
+  public long getStartedAnswerAt_ms() {
+    return this.startedAnswerAt_ms;
+  }
+
+  public void setStartedAnswerAt_ms(long startedAnswerAt_ms) {
+    this.startedAnswerAt_ms = startedAnswerAt_ms;
+  }
+
+  public long setStartedAnswerAt_msNow() {
+    return this.startedAnswerAt_ms = System.currentTimeMillis();
+  }
+
+  public boolean isAnswering() {
+    return this.answering;
+  }
+
+  public void startAnswer() {
+    this.answering = true;
+  }
+
+  public void endAnswer() {
+    this.answering = false;
+  }
+
+  public boolean isConfirmedResult() {
+    return this.confirmedResult;
+  }
+
+  public void confirmResult() {
+    this.confirmedResult = true;
+  }
+
+  public void unconfirmResult() {
+    this.confirmedResult = false;
+  }
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
@@ -27,7 +27,9 @@ public class PublicGameRoom {
   private PGameRoomRanking ranking;
   private int nextQuizIndex;
   private boolean open;
+  private long startedAnswerAt_ms;
   private boolean answering;
+  private boolean confirmedResult;
 
   @Autowired
   AsyncPGameRoomService asyncPGRService;
@@ -45,6 +47,7 @@ public class PublicGameRoom {
     this.ranking = new PGameRoomRanking();
     this.nextQuizIndex = 0;
     this.open = true;
+    this.startedAnswerAt_ms = System.currentTimeMillis();
     this.answering = false;
   }
 
@@ -158,6 +161,18 @@ public class PublicGameRoom {
     }
   }
 
+  public long getStartedAnswerAt_ms() {
+    return this.startedAnswerAt_ms;
+  }
+
+  public void setStartedAnswerAt_ms(long startedAnswerAt_ms) {
+    this.startedAnswerAt_ms = startedAnswerAt_ms;
+  }
+
+  public long setStartedAnswerAt_msNow() {
+    return this.startedAnswerAt_ms = System.currentTimeMillis();
+  }
+
   public boolean isAnswering() {
     return this.answering;
   }
@@ -168,5 +183,17 @@ public class PublicGameRoom {
 
   public void endAnswer() {
     this.answering = false;
+  }
+
+  public boolean isConfirmedResult() {
+    return this.confirmedResult;
+  }
+
+  public void confirmResult() {
+    this.confirmedResult = true;
+  }
+
+  public void unconfirmResult() {
+    this.confirmedResult = false;
   }
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
@@ -27,6 +27,7 @@ public class PublicGameRoom {
   private PGameRoomRanking ranking;
   private int nextQuizIndex;
   private boolean open;
+  private boolean answering;
 
   @Autowired
   AsyncPGameRoomService asyncPGRService;
@@ -44,6 +45,7 @@ public class PublicGameRoom {
     this.ranking = new PGameRoomRanking();
     this.nextQuizIndex = 0;
     this.open = true;
+    this.answering = false;
   }
 
   public long getGameRoomID() {
@@ -141,7 +143,7 @@ public class PublicGameRoom {
   public void removeEmitter(SseEmitter emitter) {
     emitters.remove(emitter);
   }
-  
+
     public boolean isOpen() {
     return open;
   }
@@ -156,4 +158,15 @@ public class PublicGameRoom {
     }
   }
 
+  public boolean isAnswering() {
+    return this.answering;
+  }
+
+  public void startAnswer() {
+    this.answering = true;
+  }
+
+  public void endAnswer() {
+    this.answering = false;
+  }
 }

--- a/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
+++ b/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
@@ -121,4 +121,27 @@ public class AsyncPGameRoomService {
       pageTransitionMap.put(roomID, true);
     }
   }
+
+  @Async
+  public void asyncAutoRedirectToAnswerPage(SseEmitter emitter, long roomID) {
+    logger.info("AsyncPGameRoomService.asyncAutoRedirectToAnswerPage is called with roomID: " + roomID);
+
+    try {
+      PublicGameRoom redirectToRoom =  pGameRoomManager.getPublicGameRooms().get(roomID);
+
+      emitter.send(SseEmitter.event().name("init").data("SSE connection established. Ready to auto-redirect to Answer Page of roomID: " + roomID));
+      while(true) {
+        if(redirectToRoom.isAnswering()) {
+          emitter.send(roomID);
+          break;
+        }
+
+        TimeUnit.MILLISECONDS.sleep(100L);
+      }
+    } catch(Exception e) {
+      logger.error("AsyncPGameRoomService.asyncAutoRedirectToAnswerPage Error: " + e.getClass().getName() + ":" + e.getMessage());
+    } finally {
+      emitter.complete();
+    }
+  }
 }

--- a/src/main/resources/static/js/SseAutoRedirectToAnswerPage.js
+++ b/src/main/resources/static/js/SseAutoRedirectToAnswerPage.js
@@ -1,0 +1,28 @@
+function SseAutoRedirectToAnswerPage() {
+  console.log("SseAutoRedirectToAnswerPage function is called. ")
+
+  let sse = new EventSource("/sse/transitToAnswer");
+  sse.onopen = function() {
+    console.info("SseAutoRedirectToAnserPage: SSE connection opened. ");
+  };
+  sse.onerror = function (error) {
+    console.error("SseAutoRedirectToAnserPage: SSE error: ", error);
+  };
+  sse.addEventListener('init', function (event) {
+    console.log("SseAutoRedirectToAnserPage: Init event received: " + event.data);
+  });
+  sse.onmessage = function(event) {
+    console.log("SseAutoRedirectToAnserPage: sse.onmessage Event received: " + event.data);
+
+    try {
+      if(!isNaN(event.data)) {
+        const loc = "/playing/answer?room=" + event.data;
+        console.log("Redirect to " + loc);
+        window.location.href = loc;
+      }
+
+    } catch(e) {
+      console.error("Error by " + e);
+    }
+  };
+}

--- a/src/main/resources/templates/playing/guest/wait.html
+++ b/src/main/resources/templates/playing/guest/wait.html
@@ -5,6 +5,12 @@
   <meta charset="utf-8">
   <title>Quiz_7/出題待機</title>
   <link rel="stylesheet" href="/css/origin.css" />
+  <script src="/js/SseAutoRedirectToAnswerPage.js"></script>
+  <script>
+    window.onload = function() {
+      SseAutoRedirectToAnswerPage();
+    };
+  </script>
 </head>
 
 <body>

--- a/src/main/resources/templates/playing/host/wait.html
+++ b/src/main/resources/templates/playing/host/wait.html
@@ -32,7 +32,7 @@
     </div>
 
     <div class="input-form">
-      <a th:href="@{/sse/publishQuiz(id=${nextQuiz.ID})}" class="colored_button">出題する</a>
+      <a th:href="@{/playing/start_quiz(room=${pgameroom.gameRoomID})}" class="colored_button">出題する</a>
     </div>
   </div>
 </body>


### PR DESCRIPTION
### [概要]
　タスク「[参加者]解答ページ(/playing/answer)へのSSE強制遷移機能の実装」(#64)，「クイズ出題処理の実装」(#95) の実装を行ったPR．
　タスク詳細は対応するIssueを確認してもらいたい．

### [レビュアー]
- e1b22103

### [DoD]
　※PRと同名のIssueに記載済みなので省略．

### [重要事項]
　複数のタスク(Issue)にわたったPRなので注意してもらいたい．
　タスク #95 の変数確認は，当該Controllerのコードの通り，「_/playing/start_quiz_」にクエリパラメータ「DBG=true」をつけてGETリクエストすれば確認できる．
　実装部分へのコメントアウトは要請あれば行うものとします．

### [実行/実装事項]
　(省略，PRのFiles changedを参照されたい)
　実装内容は余力あれば記載する．もしくは，要請あれば記載する．

### [以降の開発についてのメモ]
　(なし)

### [備考]
　(なし)
