### PR TITLE
[参加者]解答結果表示ページ(/playing/ans_result)のページ(ゲーム続行およびゲーム終了)の実装

### DIFF
--- a/src/main/resources/templates/playing/guest/ans_result.html
+++ b/src/main/resources/templates/playing/guest/ans_result.html
@@ -44,7 +44,7 @@
       </div>
 
       <a th:unless="${over_flag}" th:href="@{/playing/wait(room=${pgameroom.gameRoomID})}">続行</a>
-      <a th:if="${over_flag}" th:href="@{/playing/overall}">最終結果表示</a>
+      <a th:if="${over_flag}" th:href="@{/playing/overall(room=${pgameroom.gameRoomID})}">最終結果表示</a>
     </div>
 
     <div class="iframe-section">

--- a/src/main/resources/templates/playing/guest/ans_result.html
+++ b/src/main/resources/templates/playing/guest/ans_result.html
@@ -42,7 +42,8 @@
         <p>獲得点数: <span th:text="${currentQuiz.point}"></span> 点</p>
       </div>
 
-      <a th:href="@{/playing/wait(room=${pgameroom.gameRoomID})}">続行</a>
+      <a th:unless="${over_flag}" th:href="@{/playing/wait(room=${pgameroom.gameRoomID})}">続行</a>
+      <a th:if="${over_flag}" th:href="@{/playing/overall}">最終結果表示</a>
     </div>
 
     <div class="iframe-section">

--- a/src/main/resources/templates/playing/guest/ans_result.html
+++ b/src/main/resources/templates/playing/guest/ans_result.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/解答結果</title>
+  <link rel="stylesheet" href="/css/origin.css" />
+  <style>
+    .correct-choice {
+      background-color: #d4edda;
+      color: #155724;
+      font-weight: bold;
+      border: 2px solid #28a745;
+      border-radius: 5px;
+      padding: 5px 10px;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="container">
+    <div class="display">
+      <h3 th:if="${pgameroom}" th:text="${pgameroom.gameRoomName}"></h3>
+      <h3>解答結果</h3>
+      <div th:if="${currentQuiz}">
+        <p>タイトル:[[${currentQuiz.title}]]</p>
+        <p>問題文:[[${currentQuiz.description}]]</p>
+      </div>
+      <p>選択肢</p>
+      <div th:if="${currentQuizJson}">
+        <ol>
+          <li th:each="choice, iterStat : ${currentQuizJson.choices}" th:text="${choice}"
+            th:classappend="${iterStat.index == currentQuizJson.correct - 1} ? 'correct-choice' : ''"></li>
+        </ol>
+        <p>あなたの回答: （取得付加）</p>
+        <p>正解: <span th:text="${currentQuizJson.choices[currentQuizJson.correct - 1]}"></span></p>
+      </div>
+      <div>
+        <p>解答時間: （取得付加）ms</p>
+        <!-- <span th:text="${participant.answerTime}"></span> -->
+        <p>解答順位: <span th:text="${answerTime_rank}"></span> 位</p>
+        <p>獲得点数: <span th:text="${currentQuiz.point}"></span> 点</p>
+      </div>
+
+      <a th:href="@{/playing/wait(room=${pgameroom.gameRoomID})}">続行</a>
+    </div>
+
+    <div class="iframe-section">
+      <iframe th:src="@{./ranking}"></iframe>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/main/resources/templates/playing/guest/overall.html
+++ b/src/main/resources/templates/playing/guest/overall.html
@@ -3,47 +3,20 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Quiz_7/解答結果</title>
+  <title>Quiz_7/最終結果</title>
   <link rel="stylesheet" href="/css/origin.css" />
-  <style>
-    .correct-choice {
-      background-color: #d4edda;
-      color: #155724;
-      font-weight: bold;
-      border: 2px solid #28a745;
-      border-radius: 5px;
-      padding: 5px 10px;
-    }
-  </style>
 </head>
 
 <body>
   <div class="container">
     <div class="display">
-      <h3>テストページ</h3>
-      <h3>解答結果</h3>
-      <div>
-        <p>タイトル: テストページ</p>
-        <p>問題文: このページはテストページです。</p>
+      <h3 th:if="${pgameroom}" th:text="${pgameroom.gameRoomName}"></h3>
+      <div th:if="${participant}">
+        <p>[[${participant.userName}]] さんの</p>
+        <p>最終順位：[[${participantRank}]]位</p>
+        <p>最終得点：[[${participant.point}]]点</p>
       </div>
-      <p>選択肢</p>
-      <div>
-        <ol>
-          <li class="correct-choice">A</li>
-          <li>B</li>
-          <li>C</li>
-          <li>D</li>
-        </ol>
-        <p>あなたの回答: A</p>
-        <p>正解: A</p>
-      </div>
-      <div>
-        <p>解答時間: 3.0 ms</p>
-        <p>解答順位: 2 位</p>
-        <p>獲得点数: 10000 点</p>
-      </div>
-
-      <a th:href="@{/playing/overall}">最終結果表示</a>
+      <a th:href="@{/main}">メインページ</a>
     </div>
 
     <div class="iframe-section">

--- a/src/main/resources/templates/playing/guest/overall.html
+++ b/src/main/resources/templates/playing/guest/overall.html
@@ -3,20 +3,47 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Quiz_7/最終結果</title>
+  <title>Quiz_7/解答結果</title>
   <link rel="stylesheet" href="/css/origin.css" />
+  <style>
+    .correct-choice {
+      background-color: #d4edda;
+      color: #155724;
+      font-weight: bold;
+      border: 2px solid #28a745;
+      border-radius: 5px;
+      padding: 5px 10px;
+    }
+  </style>
 </head>
 
 <body>
   <div class="container">
     <div class="display">
-      <h3 th:if="${pgameroom}" th:text="${pgameroom.gameRoomName}"></h3>
-      <div th:if="${participant}">
-        <p>[[${participant.userName}]] さんの</p>
-        <p>最終順位：[[${participantRank}]]位</p>
-        <p>最終得点：[[${participant.point}]]点</p>
+      <h3>テストページ</h3>
+      <h3>解答結果</h3>
+      <div>
+        <p>タイトル: テストページ</p>
+        <p>問題文: このページはテストページです。</p>
       </div>
-      <a th:href="@{/main}">メインページ</a>
+      <p>選択肢</p>
+      <div>
+        <ol>
+          <li class="correct-choice">A</li>
+          <li>B</li>
+          <li>C</li>
+          <li>D</li>
+        </ol>
+        <p>あなたの回答: A</p>
+        <p>正解: A</p>
+      </div>
+      <div>
+        <p>解答時間: 3.0 ms</p>
+        <p>解答順位: 2 位</p>
+        <p>獲得点数: 10000 点</p>
+      </div>
+
+      <a th:href="@{/playing/overall}">最終結果表示</a>
     </div>
 
     <div class="iframe-section">


### PR DESCRIPTION
Close #60 
Close #90 
[概要]
　タスク「[参加者]解答結果表示ページ(/playing/ans_result)のページ(ゲーム続行)の実装」および「[参加者]解答結果表示ページ(/playing/ans_result)のページ(ゲーム終了)の実装」を行ったPR．

[内容と備考]
- ans_result.html
　- DoDに含まれる項目の内，取得可能なものを表示．
　- 自分の回答と解答時間，獲得点数は現状どこを参照すればよいかわからなかったため，空白または初期値を設定している．
　- 選択肢のうち，正解を目立たせようとしたが，リスト内でinline設定すると連番表示ができなかった．他の方法があれば教えてほしい．
- overall.html
　- #90 のテストページ．
　- 自分がタスク内容を誤認している気がする．多分ここに書くものじゃない．
- PlayingController.java
　- "/ans_result"に対するGETリクエストの処理実装．
　- "/overall"に対するGETリクエスト処理内でテストページに遷移しているが，この確認自体"/ans_result"でするべき．
　- 
[備考]
　すみません．多分#90 に関しては全く見当違いなことしてると思います．
　一旦#60 の確認だけしてもらって，＃90に関してアドバイス等あれば教えてください．
　＃60のDoDは「/playing/ans_result?room=1&quiz=1」等で確認できると思います．
　今日の23:59締切ということでPRは発行しましたが，改善点ばかりだと思うので，今後できるだけ早く修正していきます．