### PR TITLE
出題者回答待機/結果表示ページを実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ch.qos.logback.classic.Logger;
@@ -29,7 +28,6 @@ import oit.is.team7.quiz_7.model.QuizJson;
 import oit.is.team7.quiz_7.model.QuizTable;
 import oit.is.team7.quiz_7.model.QuizTableMapper;
 import oit.is.team7.quiz_7.model.UserAccountMapper;
-import oit.is.team7.quiz_7.utils.JsonUtils;
 
 @Controller
 @RequestMapping("/playing")
@@ -71,7 +69,6 @@ public class PlayingController {
     PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get((long) roomID);
     if (!pgroom.getHostUserName().equals(prin.getName())) {
       // ユーザがホストでなければゲスト向けの待機画面を表示
-      model.addAttribute("pgameroom", pgroom);
       return get_wait_guest(roomID, prin, model);
     }
     if (pgroom != null) {
@@ -87,9 +84,8 @@ public class PlayingController {
     long nextQuizID = pgroom.getQuizPool().get(pgroom.getNextQuizIndex());
     QuizTable nextQuiz = quizTableMapper.selectQuizTableByID((int) nextQuizID);
     model.addAttribute("nextQuiz", nextQuiz);
+    String quizJsonString = nextQuiz.getQuizJSON();
     ObjectMapper objectMapper = new ObjectMapper();
-    JsonNode quizJsonNode = nextQuiz.getQuizJSON();
-    String quizJsonString = JsonUtils.parseJsonNodeToString(quizJsonNode);
     try {
       QuizJson quizJson = objectMapper.readValue(quizJsonString, QuizJson.class);
       model.addAttribute("nextQuizJson", quizJson);
@@ -100,12 +96,11 @@ public class PlayingController {
   }
 
   @GetMapping("/ans_result")
-  public String get_ans_result_host(@RequestParam("room") int roomID, @RequestParam("quiz") int curQuizID,
+  public String get_ans_result_host(@RequestParam("room") long roomID, @RequestParam("quiz") int curQuizID,
       Principal prin, ModelMap model) {
-    PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get((long) roomID);
+    PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get(roomID);
     // if (!pgroom.getHostUserName().equals(prin.getName())) {
     // // ユーザがホストでなければゲスト向けの回答結果画面を表示
-    // model.addAttribute("pgameroom", pgroom);
     // return get_wait_guest(roomID, prin, model);
     // }
     model.addAttribute("pgameroom", pgroom);
@@ -116,9 +111,8 @@ public class PlayingController {
     model.addAttribute("quizList", quizList);
     QuizTable curQuiz = quizTableMapper.selectQuizTableByID(curQuizID);
     model.addAttribute("curQuiz", curQuiz);
+    String quizJsonString = curQuiz.getQuizJSON();
     ObjectMapper objectMapper = new ObjectMapper();
-    JsonNode quizJsonNode = curQuiz.getQuizJSON();
-    String quizJsonString = JsonUtils.parseJsonNodeToString(quizJsonNode);
     try {
       QuizJson quizJson = objectMapper.readValue(quizJsonString, QuizJson.class);
       model.addAttribute("curQuizJson", quizJson);

--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -100,7 +100,8 @@ public class PlayingController {
   }
 
   @GetMapping("/ans_result")
-  public String get_ans_result_host(@RequestParam("room") int roomID, Principal prin, ModelMap model) {
+  public String get_ans_result_host(@RequestParam("room") int roomID, @RequestParam("quiz") int curQuizID,
+      Principal prin, ModelMap model) {
     PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get((long) roomID);
     // if (!pgroom.getHostUserName().equals(prin.getName())) {
     // // ユーザがホストでなければゲスト向けの回答結果画面を表示
@@ -113,8 +114,7 @@ public class PlayingController {
       quizList.add(quizTableMapper.selectQuizTableByID((int) quizID));
     }
     model.addAttribute("quizList", quizList);
-    long curQuizID = pgroom.getQuizPool().get(pgroom.getNextQuizIndex());
-    QuizTable curQuiz = quizTableMapper.selectQuizTableByID((int) curQuizID);
+    QuizTable curQuiz = quizTableMapper.selectQuizTableByID(curQuizID);
     model.addAttribute("curQuiz", curQuiz);
     ObjectMapper objectMapper = new ObjectMapper();
     JsonNode quizJsonNode = curQuiz.getQuizJSON();

--- a/src/main/java/oit/is/team7/quiz_7/controller/SseController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/SseController.java
@@ -47,7 +47,7 @@ public class SseController {
   }
 
   @GetMapping("/answerList")
-  public SseEmitter getAnswerList(@RequestParam("room") long roomID) {
+  public SseEmitter getAnswerList(@RequestParam("room") long roomID, @RequestParam("quiz") int quizID) {
     logger.info("getAnswerList called with roomID:" + roomID);
     final SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
     PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get(roomID);
@@ -61,7 +61,7 @@ public class SseController {
       // 初期メッセージを送信して接続が確立されたことを確認
       logger.info("Sending init message to roomID: " + roomID);
       emitter.send(SseEmitter.event().name("init").data("SSE connection established"));
-      asyncPGRService.asyncSendAnswerList(pgroom);
+      asyncPGRService.asyncSendAnswerList(pgroom, quizID);
     } catch (Exception e) {
       logger.error("Error in getAnswerList(...): {}", e.getMessage());
       emitter.completeWithError(e);

--- a/src/main/java/oit/is/team7/quiz_7/controller/SseController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/SseController.java
@@ -45,4 +45,27 @@ public class SseController {
     }
     return emitter;
   }
+
+  @GetMapping("/answerList")
+  public SseEmitter getAnswerList(@RequestParam("room") long roomID) {
+    logger.info("getAnswerList called with roomID:" + roomID);
+    final SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+    PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get(roomID);
+    if (pgroom == null) {
+      logger.error("Room not found: {}", roomID);
+      emitter.completeWithError(new Exception("Room not found"));
+      return emitter;
+    }
+    pgroom.addEmitter(emitter);
+    try {
+      // 初期メッセージを送信して接続が確立されたことを確認
+      logger.info("Sending init message to roomID: " + roomID);
+      emitter.send(SseEmitter.event().name("init").data("SSE connection established"));
+      asyncPGRService.asyncSendAnswerList(pgroom);
+    } catch (Exception e) {
+      logger.error("Error in getAnswerList(...): {}", e.getMessage());
+      emitter.completeWithError(e);
+    }
+    return emitter;
+  }
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/QuizTable.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/QuizTable.java
@@ -2,6 +2,8 @@ package oit.is.team7.quiz_7.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import oit.is.team7.quiz_7.utils.JsonUtils;
+
 public class QuizTable {
   int ID;
   int quizFormatID;
@@ -69,8 +71,8 @@ public class QuizTable {
     this.point = point;
   }
 
-  public JsonNode getQuizJSON() {
-    return quizJSON;
+  public String getQuizJSON() {
+    return JsonUtils.parseJsonNodeToString(this.quizJSON);
   }
 
   public void setQuizJSON(JsonNode quizJSON) {

--- a/src/main/resources/static/js/HostAnsResult.js
+++ b/src/main/resources/static/js/HostAnsResult.js
@@ -1,23 +1,38 @@
 window.onload = function () {
   var roomID = new URLSearchParams(window.location.search).get('room');
-  var sse = new EventSource('/sse/answerList?room=' + roomID);
-  console.log("EventSource created with URL: /sse/answerList?room=" + roomID);
+  var quizID = new URLSearchParams(window.location.search).get('quiz');
+  var sse = new EventSource('/sse/answerList?room=' + roomID + '&quiz=' + quizID);
+  console.log("EventSource created with URL: /sse/answerList?room=" + roomID + "&quiz=" + quizID);
   sse.onopen = function () {
     console.log("SSE connection opened");
   }
+  // 1秒ごとに届く
   sse.addEventListener('refresh', function (event) {
     console.log("Refresh event received: " + event.data);
     let participantsList = JSON.parse(event.data);
-    let answerList = "<ul>";
-    participantsList.forEach((participant) => {
-      if (participant.answerContents === null) {
-        answerList += "<li>" + participant.userName + ": 未回答</li>";
-      } else {
-        answerList += "<li>" + participant.userName + ": " + participant.answerContents + " " + participant.answerTime + "</li>";
-      }
-    });
-    answerList += "</ul>";
-    document.getElementById("answerList").innerHTML = answerList;
+    if (participantsList.length === 0) {
+      return;
+    } else {
+      let answerList = "<ul>";
+      participantsList.forEach((participant) => {
+        if (participant.answerContents === null) {
+          answerList += "<li>" + participant.userName + ": 未回答</li>";
+        } else {
+          answerList += "<li>" + participant.userName + ": " + participant.answerContents + " " + participant.answerTime + "</li>";
+        }
+      });
+      answerList += "</ul>";
+      document.getElementById("answerList").innerHTML = answerList;
+    }
+  });
+  sse.addEventListener('countdown', function (event) {
+    console.log("Countdown event received: " + event.data);
+    let countdown = Math.round(event.data);
+    let remainTime = "<h3>制限時間: " + countdown + " 秒</h3>";
+    if (countdown <= 0) {
+      remainTime = "<h3>制限時間: 終了</h3>";
+    }
+    document.getElementById("remainTime").innerHTML = remainTime;
   });
   sse.onmessage = function (event) {
     console.log("Event received:" + event.data);

--- a/src/main/resources/static/js/HostAnsResult.js
+++ b/src/main/resources/static/js/HostAnsResult.js
@@ -13,26 +13,35 @@ window.onload = function () {
     if (participantsList.length === 0) {
       return;
     } else {
-      let answerList = "<ul>";
+      let answerList = "<tbody>";
       participantsList.forEach((participant) => {
-        if (participant.answerContents === null) {
-          answerList += "<li>" + participant.userName + ": 未回答</li>";
+        if (participant.answerContent === null) {
+          answerList += "<tr><td>" + participant.userName + "</td><td>未解答</td><td align='right'>----</td></tr>";
         } else {
-          answerList += "<li>" + participant.userName + ": " + participant.answerContents + " " + participant.answerTime + "</li>";
+          answerList += "<tr><td>" + participant.userName + "</td><td>" + participant.answerContent + "</td><td>" + participant.answerTime + "</td></tr>";
         }
       });
-      answerList += "</ul>";
+      answerList += "</tbody>";
       document.getElementById("answerList").innerHTML = answerList;
     }
   });
   sse.addEventListener('countdown', function (event) {
     console.log("Countdown event received: " + event.data);
     let countdown = Math.round(event.data);
-    let remainTime = "<h3>制限時間: " + countdown + " 秒</h3>";
+    let remainTime = "<h3>残り解答時間: " + countdown + " 秒</h3>";
     if (countdown <= 0) {
-      remainTime = "<h3>制限時間: 終了</h3>";
+      remainTime = "<h3>残り解答時間: 終了</h3>";
     }
     document.getElementById("remainTime").innerHTML = remainTime;
+  });
+  sse.addEventListener('transition', function (event) {
+    console.log("Transition event received: " + event.data);
+    let data = JSON.parse(event.data);
+    if (data === "toRanking") {
+      window.location.href = "/playing/ranking?room=" + roomID;
+    } else if (data === "toOverall") {
+      window.location.href = "/playing/overall?room=" + roomID;
+    }
   });
   sse.onmessage = function (event) {
     console.log("Event received:" + event.data);

--- a/src/main/resources/static/js/HostAnsResult.js
+++ b/src/main/resources/static/js/HostAnsResult.js
@@ -1,0 +1,31 @@
+window.onload = function () {
+  var roomID = new URLSearchParams(window.location.search).get('room');
+  var sse = new EventSource('/sse/answerList?room=' + roomID);
+  console.log("EventSource created with URL: /sse/answerList?room=" + roomID);
+  sse.onopen = function () {
+    console.log("SSE connection opened");
+  }
+  sse.addEventListener('refresh', function (event) {
+    console.log("Refresh event received: " + event.data);
+    let participantsList = JSON.parse(event.data);
+    let answerList = "<ul>";
+    participantsList.forEach((participant) => {
+      if (participant.answerContents === null) {
+        answerList += "<li>" + participant.userName + ": 未回答</li>";
+      } else {
+        answerList += "<li>" + participant.userName + ": " + participant.answerContents + " " + participant.answerTime + "</li>";
+      }
+    });
+    answerList += "</ul>";
+    document.getElementById("answerList").innerHTML = answerList;
+  });
+  sse.onmessage = function (event) {
+    console.log("Event received:" + event.data);
+  }
+  sse.addEventListener('init', function (event) {
+    console.log("Init event received: " + event.data);
+  });
+  sse.onerror = function (error) {
+    console.log("SSE error:", error);
+  }
+}

--- a/src/main/resources/templates/playing/host/ans_result.html
+++ b/src/main/resources/templates/playing/host/ans_result.html
@@ -12,35 +12,32 @@
   <div class="container">
     <div class="display">
       <h3 th:if="${pgameroom}" th:text="${pgameroom.gameRoomName}"></h3>
+      <h3>出題中のクイズ</h3>
+      <div th:if="${curQuiz}">
+        <p>タイトル:[[${curQuiz.title}]]</p>
+        <p>問題文:[[${curQuiz.description}]]</p>
+      </div>
+      <p>選択肢</p>
+      <div th:if="${curQuizJson}">
+        <ol>
+          <li th:each="choice : ${curQuizJson.choices}" th:text="${choice}"></li>
+        </ol>
+        <p>答え：[[${curQuizJson.correct}]]</p>
+      </div>
+      <!-- 残り回答時間 -->
+      <h3 id="remainTime"></h3>
+    </div>
+
+    <div class="display">
+      <!-- 全参加者の名前と回答内容のリスト -->
+      <h3>回答結果</h3>
       <div class="scroll-full">
-        <h3>出題中のクイズ</h3>
-        <div th:if="${curQuiz}">
-          <p>タイトル:[[${curQuiz.title}]]</p>
-          <p>問題文:[[${curQuiz.description}]]</p>
-        </div>
-        <p>選択肢</p>
-        <div th:if="${curQuizJson}">
-          <ol>
-            <li th:each="choice : ${curQuizJson.choices}" th:text="${choice}"></li>
-          </ol>
-          <p>答え：[[${curQuizJson.correct}]]</p>
-        </div>
-        <!-- 全参加者の名前と回答内容のリスト -->
-        <h3>回答結果</h3>
         <div th:if="${participantsList}">
           <ul th:each="participant : ${participantsList}" id="answerList">
             <li th:text="${participant.userName} + ': 未回答'"></li>
           </ul>
         </div>
       </div>
-      <!-- 残り回答時間 -->
-      <div>制限時間：<p id="remainTime" th:text="${curQuiz.timelimit} + ' 秒'"></p>
-      </div>
-    </div>
-
-    <div class="input-form">
-      <a id="toRanking"></a>
-      <a id="toFinalResult"></a>
     </div>
   </div>
 </body>

--- a/src/main/resources/templates/playing/host/ans_result.html
+++ b/src/main/resources/templates/playing/host/ans_result.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Quiz_7/回答待機</title>
+  <title>Quiz_7/解答状況</title>
   <link rel="stylesheet" href="/css/origin.css" />
   <script src="/js/HostAnsResult.js"></script>
 </head>
@@ -24,19 +24,30 @@
         </ol>
         <p>答え：[[${curQuizJson.correct}]]</p>
       </div>
-      <!-- 残り回答時間 -->
+      <!-- 残り解答時間 -->
       <h3 id="remainTime"></h3>
     </div>
 
     <div class="display">
-      <!-- 全参加者の名前と回答内容のリスト -->
-      <h3>回答結果</h3>
+      <!-- 全参加者の名前と解答内容のリスト -->
+      <h3>解答結果</h3>
       <div class="scroll-full">
-        <div th:if="${participantsList}">
-          <ul th:each="participant : ${participantsList}" id="answerList">
-            <li th:text="${participant.userName} + ': 未回答'"></li>
-          </ul>
-        </div>
+        <table th:if="${participantsList}">
+          <thead>
+            <tr>
+              <th>名前</th>
+              <th>解答</th>
+              <th>解答タイム</th>
+            </tr>
+          </thead>
+          <tbody id="answerList">
+            <tr th:each="participant : ${participantsList}">
+              <td th:text="${participant.userName}"></td>
+              <td></td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/src/main/resources/templates/playing/host/ans_result.html
+++ b/src/main/resources/templates/playing/host/ans_result.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/回答待機</title>
+  <link rel="stylesheet" href="/css/origin.css" />
+  <script src="/js/HostAnsResult.js"></script>
+</head>
+
+<body>
+  <div class="container">
+    <div class="display">
+      <h3 th:if="${pgameroom}" th:text="${pgameroom.gameRoomName}"></h3>
+      <div class="scroll-full">
+        <h3>出題中のクイズ</h3>
+        <div th:if="${curQuiz}">
+          <p>タイトル:[[${curQuiz.title}]]</p>
+          <p>問題文:[[${curQuiz.description}]]</p>
+        </div>
+        <p>選択肢</p>
+        <div th:if="${curQuizJson}">
+          <ol>
+            <li th:each="choice : ${curQuizJson.choices}" th:text="${choice}"></li>
+          </ol>
+          <p>答え：[[${curQuizJson.correct}]]</p>
+        </div>
+        <!-- 全参加者の名前と回答内容のリスト -->
+        <h3>回答結果</h3>
+        <div th:if="${participantsList}">
+          <ul th:each="participant : ${participantsList}" id="answerList">
+            <li th:text="${participant.userName} + ': 未回答'"></li>
+          </ul>
+        </div>
+      </div>
+      <!-- 残り回答時間 -->
+      <div>制限時間：<p id="remainTime" th:text="${curQuiz.timelimit} + ' 秒'"></p>
+      </div>
+    </div>
+
+    <div class="input-form">
+      <a id="toRanking"></a>
+      <a id="toFinalResult"></a>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/main/resources/templates/playing/host/wait.html
+++ b/src/main/resources/templates/playing/host/wait.html
@@ -32,7 +32,7 @@
     </div>
 
     <div class="input-form">
-      <a th:href="@{/sse/publishQuiz(id=${nextQuiz.ID})}" class="colored_button">出題する</a>
+      <a th:href="@{/playing/ans_result(room=${pgameroom.gameRoomID})}" class="colored_button">出題する</a>
     </div>
   </div>
 </body>

--- a/src/main/resources/templates/playing/host/wait.html
+++ b/src/main/resources/templates/playing/host/wait.html
@@ -32,7 +32,8 @@
     </div>
 
     <div class="input-form">
-      <a th:href="@{/playing/ans_result(room=${pgameroom.gameRoomID})}" class="colored_button">出題する</a>
+      <a th:href="@{/playing/ans_result(room=${pgameroom.gameRoomID}, quiz=${nextQuiz.ID})}"
+        class="colored_button">出題する</a>
     </div>
   </div>
 </body>


### PR DESCRIPTION
Close #53 

開発内容
- PlayingController に get_ans_result_host() メソッドを実装
  - ついでに QuizTable の getQuizJSON() を改善（JsonNode を隠蔽して直接 String が得られるようにした）
- SseController に解答状況を取得するためのエンドポイント（/sse/answerList）を実装
- AsyncPGameRoomService に asyncSendAnswerList() メソッドを実装
- HostAnsResult.js を作成
- /playing/host/ans_result.html を作成

備考
- #53 のDoDにおいて、ページ遷移に関する部分を変更したので要確認