### PR TITLE
[参加者]解答時間終了後処理完了時の自動的画面遷移の実装 の完了

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/SseController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/SseController.java
@@ -1,5 +1,7 @@
 package oit.is.team7.quiz_7.controller;
 
+import java.security.Principal;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +13,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import oit.is.team7.quiz_7.model.PGameRoomManager;
 import oit.is.team7.quiz_7.model.PublicGameRoom;
+import oit.is.team7.quiz_7.model.UserAccountMapper;
 import oit.is.team7.quiz_7.service.AsyncPGameRoomService;
 
 @RestController
@@ -22,6 +25,9 @@ public class SseController {
 
   @Autowired
   PGameRoomManager pGameRoomManager;
+
+  @Autowired
+  UserAccountMapper userAccountMapper;
 
   // 参加者リストを取得するエンドポイント
   @GetMapping("/participantsList")
@@ -92,6 +98,21 @@ public class SseController {
       logger.error("Error in getAnswerList(...): {}", e.getMessage());
       emitter.completeWithError(e);
     }
+    return emitter;
+  }
+
+  // 解答結果表示ページ(/playing/ans_result)に自動遷移させるエンドポイント
+  @GetMapping("/transitToAnsResult")
+  public SseEmitter transitToAnsResult(Principal prin) {
+    logger.info("SseController.transitToAnsResult is called by user '" + prin.getName() + "'. ");
+
+    final SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+    final long userID = userAccountMapper.selectUserAccountByUsername(prin.getName()).getId();
+    final long roomID = pGameRoomManager.getBelonging().get(userID);
+    final long quizID = pGameRoomManager.getPublicGameRooms().get(roomID).getNextQuizID();
+
+    asyncPGRService.asyncAutoRedirectToAnsResultPage(emitter, roomID, quizID);
+
     return emitter;
   }
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/PublicGameRoom.java
@@ -27,6 +27,7 @@ public class PublicGameRoom {
   private PGameRoomRanking ranking;
   private int nextQuizIndex;
   private boolean open;
+  private boolean confirmedResult;
 
   @Autowired
   AsyncPGameRoomService asyncPGRService;
@@ -123,6 +124,14 @@ public class PublicGameRoom {
     this.nextQuizIndex++;
   }
 
+  public long getNextQuizID() {
+    if(this.nextQuizIndex < 0 || this.quizPool.size() <= this.nextQuizIndex) {
+      throw new IllegalStateException("quizPoolの範囲外の添字を参照しようとしました．");
+    }
+
+    return this.quizPool.get(this.nextQuizIndex);
+  }
+
   public void removeParticipant(long userID) {
     participants.remove(userID);
   }
@@ -141,7 +150,7 @@ public class PublicGameRoom {
   public void removeEmitter(SseEmitter emitter) {
     emitters.remove(emitter);
   }
-  
+
     public boolean isOpen() {
     return open;
   }
@@ -156,4 +165,15 @@ public class PublicGameRoom {
     }
   }
 
+  public boolean isConfirmedResult() {
+    return this.confirmedResult;
+  }
+
+  public void confirmResult() {
+    this.confirmedResult = true;
+  }
+
+  public void unconfirmResult() {
+    this.confirmedResult = false;
+  }
 }

--- a/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
+++ b/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
@@ -186,4 +186,26 @@ public class AsyncPGameRoomService {
     }
   }
 
+  @Async
+  public void asyncAutoRedirectToAnsResultPage(SseEmitter emitter, final long roomID, final long quizID) {
+    logger.info("AsyncPGameRoomService.asyncAutoRedirectToAnsResultPage is called with roomID: " + roomID + ", quizID: " + quizID);
+
+    try {
+      PublicGameRoom redirectToRoom =  pGameRoomManager.getPublicGameRooms().get(roomID);
+
+      emitter.send(SseEmitter.event().name("init").data("SSE connection established. Ready to auto-redirect to AnsResult Page of roomID: " + roomID + ", quizID: " + quizID));
+      while(true) {
+        if(redirectToRoom.isConfirmedResult()) {
+          emitter.send("room=" + roomID + "&quiz=" + quizID);
+          break;
+        }
+
+        TimeUnit.MILLISECONDS.sleep(1000L);
+      }
+    } catch(Exception e) {
+      logger.error("AsyncPGameRoomService.asyncAutoRedirectToAnsResultPage Error: " + e.getClass().getName() + ":" + e.getMessage());
+    } finally {
+      emitter.complete();
+    }
+  }
 }

--- a/src/main/resources/static/js/SseAutoRedirectToAnsResultPage.js
+++ b/src/main/resources/static/js/SseAutoRedirectToAnsResultPage.js
@@ -15,11 +15,9 @@ function SseAutoRedirectToAnsResultPage() {
     console.log("SseAutoRedirectToAnsResultPage: sse.onmessage Event received: " + event.data);
 
     try {
-      if(!isNaN(event.data)) {
-        const loc = "/playing/ans_result?" + event.data;
-        console.log("Redirect to " + loc);
-        window.location.href = loc;
-      }
+      const loc = "/playing/ans_result?" + event.data;
+      console.log("Redirect to " + loc);
+      window.location.href = loc;
 
     } catch(e) {
       console.error("Error by " + e);

--- a/src/main/resources/static/js/SseAutoRedirectToAnsResultPage.js
+++ b/src/main/resources/static/js/SseAutoRedirectToAnsResultPage.js
@@ -1,0 +1,28 @@
+function SseAutoRedirectToAnsResultPage() {
+  console.log("SseAutoRedirectToAnsResultPage function is called. ")
+
+  let sse = new EventSource("/sse/transitToAnsResult");
+  sse.onopen = function() {
+    console.info("SseAutoRedirectToAnsResultPage: SSE connection opened. ");
+  };
+  sse.onerror = function (error) {
+    console.error("SseAutoRedirectToAnsResultPage: SSE error: ", error);
+  };
+  sse.addEventListener('init', function (event) {
+    console.log("SseAutoRedirectToAnsResultPage: Init event received: " + event.data);
+  });
+  sse.onmessage = function(event) {
+    console.log("SseAutoRedirectToAnsResultPage: sse.onmessage Event received: " + event.data);
+
+    try {
+      if(!isNaN(event.data)) {
+        const loc = "/playing/ans_result?" + event.data;
+        console.log("Redirect to " + loc);
+        window.location.href = loc;
+      }
+
+    } catch(e) {
+      console.error("Error by " + e);
+    }
+  };
+}

--- a/src/main/resources/templates/playing/answer_4choices.html
+++ b/src/main/resources/templates/playing/answer_4choices.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/解答(4択クイズ)</title>
+  <link rel="stylesheet" href="/css/origin.css" />
+  <style>
+    #quiz-desc {
+      background-color: white;
+      height: 30%;
+      overflow: auto;
+    }
+
+    #quiz-form {
+      height: 30%;
+      width: 100%;
+    }
+
+    #quiz-form table {
+      height: 100%;
+      width: 100%;
+    }
+
+    #quiz-form input {
+      height: 100%;
+      width: 100%;
+      border: solid;
+    }
+
+    #quiz-form input:hover {
+      background-color: #add8e6;
+      color: white;
+    }
+  </style>
+
+  <script src="/js/SseAutoRedirectToAnsResultPage.js"></script>
+  <script type="text/javascript" th:inline="javascript">
+    function countdown_timer() {
+      const START_TIME_MS = Date.now();
+      const RECEIVED_REMAIN_TIME_MS = [[${remainAnsTime_ms}]];
+
+      const quizTimer = document.getElementById("QuizTimer");
+
+      setInterval(function() {
+        const NOW_TIME_MS = Date.now();
+        let REMAIN_TIME_MS = RECEIVED_REMAIN_TIME_MS - (NOW_TIME_MS - START_TIME_MS);
+
+        quizTimer.innerText = (Math.floor(REMAIN_TIME_MS / 100) / 10) + 's';
+      }, 100);
+    }
+  </script>
+  <script type="text/javascript">
+    window.onload = function() {
+      SseAutoRedirectToAnsResultPage();
+      countdown_timer();
+    };
+  </script>
+</head>
+
+<body>
+  <div class="container">
+    <div class="display">
+      <h3 id="quiz-title">[[${title}]]</h3>
+      <p id="quiz-desc">[[${description}]]</p>
+      <form th:action="@{./answer_4choices(room=${roomID})}" method="post" id="quiz-form">
+        <table>
+          <tr>
+            <td><input type="submit" name="choiceNo1" th:value="${choices1}" th:disabled="${yourChoiceContent}" /></td>
+            <td><input type="submit" name="choiceNo2" th:value="${choices2}" th:disabled="${yourChoiceContent}" /></td>
+          </tr>
+          <tr>
+            <td><input type="submit" name="choiceNo3" th:value="${choices3}" th:disabled="${yourChoiceContent}" /></td>
+            <td><input type="submit" name="choiceNo4" th:value="${choices4}" th:disabled="${yourChoiceContent}" /></td>
+          </tr>
+        </table>
+      </form>
+
+      <p>
+        解答残り時間: <span id="QuizTimer" />
+      </p>
+
+      <p>
+        <span id="ansResultTime" th:if="${yourAnsTime} and ${quizTimelimit}">あなたの解答時間: [[${yourAnsTime}]] / [[${quizTimelimit}]]s <br /></span>
+        <span id="ansResultChoice" th:if="${yourChoiceContent}">あなたの解答選択肢: [[${yourChoiceContent}]] <br /></span>
+      </p>
+
+      <p th:if="${error_result}" th:text="${error_result}" class="error-message"></p>
+    </div>
+
+    <div class="iframe-section">
+      <iframe th:src="@{'./ranking?room=' + ${roomID} + '&user=' + ${userID}}"></iframe>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
Close #96

### [概要]
　タスク「[参加者]解答時間終了後処理完了時の自動的画面遷移の実装」(#96) の実装を行ったPR．
　タスク詳細は対応するIssueを確認してもらいたい．

### [レビュアー]
- e1b22103

### [DoD]
　※PRと同名のIssueに記載済みなので省略．

### [重要事項]
　PR #102 と同様の方法で実装している．ただし，動作確認に関してはシステムが一通り結合したときに改めて確認したいと思います．そのため，レビューはDoDに沿っての構造の確認をすることのみをお願いしたいと思います．
なお，実装内容的にrebaseを行うべきものでしたが，rebaseの競合プレビューをみたところ，解決しにくい内容が含まれていたため，これを回避しています．結果的には，[src/main/resources/templates/playing/answer_4choices.html](https://github.com/Yura-Mp/quiz_7/pull/108/files#diff-13feb4c3ab10b1e5135e2c38e47c818bae54af0bcf8b6c64dd7acf17f9a11a56) に関して，PR #108 からコピーを行っています．おそらくこれによる競合も発生し得るので，すみませんが留意ください．
　実装部分へのコメントアウトは要請あれば行うものとします．

### [実行/実装事項]
　(省略，PRのFiles changedを参照されたい)
　実装内容は余力あれば記載する．もしくは，要請あれば記載する．

### [以降の開発についてのメモ]
　(なし)

### [備考]
　(なし)
