### PR TITLE
出題者 ランキング表示ページの実装

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/GameroomController.java
@@ -17,8 +17,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import oit.is.team7.quiz_7.model.Gameroom;
 import oit.is.team7.quiz_7.model.GameroomMapper;
@@ -197,11 +195,6 @@ public class GameroomController {
       @RequestParam String choice2, @RequestParam String choice3, @RequestParam String choice4,
       Principal principal, ModelMap model) throws JsonProcessingException {
 
-    QuizJson quizJson = new QuizJson();
-    quizJson.correct = correct_num;
-    quizJson.choices = new String[] { choice1, choice2, choice3, choice4 };
-    ObjectMapper objectMapper = new ObjectMapper();
-
     model.addAttribute("gameroom", gameroomMapper.selectGameroomByID(roomID)); // 編集対象のゲームルームの情報を追加
     String[] fields = { title, description, choice1, choice2, choice3, choice4 };
     for (String field : fields) {
@@ -213,13 +206,15 @@ public class GameroomController {
 
     int hostId = userAccountMapper.selectUserAccountByUsername(principal.getName()).getId();
     int formatId = quizFormatListMapper.selectQuizFormatByFormat("4choices").getId();
-    JsonNode jsonNode = objectMapper.valueToTree(quizJson);
+    String[] choices = new String[] { choice1, choice2, choice3, choice4 };
+    QuizJson newQuizJson = new QuizJson(correct_num, choices);
+
     QuizTable newQuizTable = new QuizTable();
     newQuizTable.setQuizFormatID(formatId);
     newQuizTable.setAuthorID(hostId);
     newQuizTable.setTitle(title);
     newQuizTable.setDescription(description);
-    newQuizTable.setQuizJSON(jsonNode);
+    newQuizTable.setRawQuizJSON(newQuizJson);
     quizTableMapper.insertQuizTable(newQuizTable);
 
     HasQuiz latestHasQuiz = hasQuizMapper.maxIndexByRoomID(roomID);

--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -132,6 +132,24 @@ public class PlayingController {
     return "/playing/host/ans_result.html";
   }
 
+  // 出題者のランキング表示ページ
+  @GetMapping("/quiz_result")
+  public String get_result(@RequestParam("room") int roomID, @RequestParam("quiz") int curQuizID, ModelMap model) {
+    PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get((long) roomID);
+    model.addAttribute("pgameroom", pgroom);
+    QuizTable curQuiz = quizTableMapper.selectQuizTableByID(curQuizID);
+    model.addAttribute("curQuiz", curQuiz);
+    String quizJsonString = curQuiz.getQuizJSON();
+    ObjectMapper objectMapper = new ObjectMapper();
+    try {
+      QuizJson quizJson = objectMapper.readValue(quizJsonString, QuizJson.class);
+      model.addAttribute("curQuizJson", quizJson);
+    } catch (Exception e) {
+      logger.error("Error at parsing quizJson: " + e.toString());
+    }
+    return "/playing/host/quiz_result.html";
+  }
+
   @GetMapping("/overall")
   public String get_overall_host(@RequestParam("room") int roomID, Principal prin, ModelMap model) {
     PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get((long) roomID);

--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -134,7 +134,7 @@ public class PlayingController {
 
   // 出題者のランキング表示ページ
   @GetMapping("/quiz_result")
-  public String get_result(@RequestParam("room") int roomID, @RequestParam("quiz") int curQuizID, ModelMap model) {
+  public String get_quiz_result(@RequestParam("room") int roomID, @RequestParam("quiz") int curQuizID, ModelMap model) {
     PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get((long) roomID);
     model.addAttribute("pgameroom", pgroom);
     QuizTable curQuiz = quizTableMapper.selectQuizTableByID(curQuizID);

--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -90,7 +90,8 @@ public class PlayingController {
     long nextQuizID = pgroom.getQuizPool().get(pgroom.getNextQuizIndex());
     QuizTable nextQuiz = quizTableMapper.selectQuizTableByID((int) nextQuizID);
     model.addAttribute("nextQuiz", nextQuiz);
-    String quizJsonString = nextQuiz.getQuizJSON();
+    String quizJsonString = nextQuiz.getParsableQuizJSON();
+    logger.info("quizJsonString: " + quizJsonString);
     ObjectMapper objectMapper = new ObjectMapper();
     try {
       QuizJson quizJson = objectMapper.readValue(quizJsonString, QuizJson.class);
@@ -117,7 +118,7 @@ public class PlayingController {
     model.addAttribute("quizList", quizList);
     QuizTable curQuiz = quizTableMapper.selectQuizTableByID(curQuizID);
     model.addAttribute("curQuiz", curQuiz);
-    String quizJsonString = curQuiz.getQuizJSON();
+    String quizJsonString = curQuiz.getParsableQuizJSON();
     ObjectMapper objectMapper = new ObjectMapper();
     try {
       QuizJson quizJson = objectMapper.readValue(quizJsonString, QuizJson.class);
@@ -139,7 +140,7 @@ public class PlayingController {
     model.addAttribute("pgameroom", pgroom);
     QuizTable curQuiz = quizTableMapper.selectQuizTableByID(curQuizID);
     model.addAttribute("curQuiz", curQuiz);
-    String quizJsonString = curQuiz.getQuizJSON();
+    String quizJsonString = curQuiz.getParsableQuizJSON();
     ObjectMapper objectMapper = new ObjectMapper();
     try {
       QuizJson quizJson = objectMapper.readValue(quizJsonString, QuizJson.class);

--- a/src/main/java/oit/is/team7/quiz_7/model/Gameroom.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/Gameroom.java
@@ -37,5 +37,4 @@ public class Gameroom {
   public void setDescription(String description) {
     this.description = description;
   }
-
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/QuizTable.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/QuizTable.java
@@ -1,6 +1,7 @@
 package oit.is.team7.quiz_7.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import oit.is.team7.quiz_7.utils.JsonUtils;
 
@@ -71,13 +72,23 @@ public class QuizTable {
     this.point = point;
   }
 
-  // objectMapper.readValue() で QuizJson オブジェクトに変換可能な形式の JSON 文字列を返す
   public String getQuizJSON() {
-    return JsonUtils.parseJsonNodeToString(this.quizJSON);
+    return JsonUtils.parseJsonNodeToString(quizJSON);
+  }
+
+  // ObjectMapper.readValue() で QuizJson オブジェクトに変換可能な JSON 文字列を返す
+  public String getParsableQuizJSON() {
+    return getQuizJSON().substring(1, getQuizJSON().length() - 1);
   }
 
   public void setQuizJSON(JsonNode quizJSON) {
     this.quizJSON = quizJSON;
+  }
+
+  // QuizJson オブジェクトを 直接セットするメソッド
+  public void setRawQuizJSON(QuizJson quizJson) {
+    ObjectMapper mapper = new ObjectMapper();
+    this.quizJSON = mapper.valueToTree(quizJson);
   }
 
 }

--- a/src/main/java/oit/is/team7/quiz_7/model/QuizTable.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/QuizTable.java
@@ -71,6 +71,7 @@ public class QuizTable {
     this.point = point;
   }
 
+  // objectMapper.readValue() で QuizJson オブジェクトに変換可能な形式の JSON 文字列を返す
   public String getQuizJSON() {
     return JsonUtils.parseJsonNodeToString(this.quizJSON);
   }

--- a/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
+++ b/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
@@ -44,18 +44,19 @@ public class AsyncPGameRoomService {
           logger.info("Participants list updated: " + participants);
 
           String jsonData = new ObjectMapper().writeValueAsString(participants);
-
-          for (SseEmitter emitter : pgroom.getEmitters()) {
-            try {
-              logger.info("Sending event to emitter: " + emitter + " with data: " + jsonData);
-              emitter.send(SseEmitter.event().name("participantsList").data(jsonData));
-              logger.info("Event sent: " + jsonData);
-            } catch (Exception e) {
-              pgroom.removeEmitter(emitter);
-              logger.error("Error sending event: " + e.getMessage());
+          synchronized (pgroom.getEmitters()) {
+            for (SseEmitter emitter : pgroom.getEmitters()) {
+              try {
+                logger.info("Sending event to emitter: " + emitter + " with data: " + jsonData);
+                emitter.send(SseEmitter.event().name("participantsList").data(jsonData));
+                logger.info("Event sent: " + jsonData);
+              } catch (Exception e) {
+                pgroom.removeEmitter(emitter);
+                logger.error("Error sending event: " + e.getMessage());
+              }
             }
+            logger.info("Participants list sent");
           }
-          logger.info("Participants list sent");
         }
         TimeUnit.MILLISECONDS.sleep(1000);
       }

--- a/src/main/java/oit/is/team7/quiz_7/utils/JsonUtils.java
+++ b/src/main/java/oit/is/team7/quiz_7/utils/JsonUtils.java
@@ -9,6 +9,6 @@ public class JsonUtils {
       return null;
     }
     String jsonString = jsonNode.toString();
-    return jsonString.substring(1, jsonString.length() - 1).replace("\\\"", "\"");
+    return "{" + jsonString.substring(1, jsonString.length() - 1).replace("\\\"", "\"") + "}";
   }
 }

--- a/src/main/resources/static/js/HostAnsResult.js
+++ b/src/main/resources/static/js/HostAnsResult.js
@@ -38,7 +38,7 @@ window.onload = function () {
     console.log("Transition event received: " + event.data);
     let data = JSON.parse(event.data);
     if (data === "toRanking") {
-      window.location.href = "/playing/ranking?room=" + roomID;
+      window.location.href = "/playing/ranking?room=" + roomID + "&quiz=" + quizID;
     } else if (data === "toOverall") {
       window.location.href = "/playing/overall?room=" + roomID;
     }

--- a/src/main/resources/static/js/HostAnsResult.js
+++ b/src/main/resources/static/js/HostAnsResult.js
@@ -38,7 +38,7 @@ window.onload = function () {
     console.log("Transition event received: " + event.data);
     let data = JSON.parse(event.data);
     if (data === "toRanking") {
-      window.location.href = "/playing/ranking?room=" + roomID + "&quiz=" + quizID;
+      window.location.href = "/playing/quiz_result?room=" + roomID + "&quiz=" + quizID;
     } else if (data === "toOverall") {
       window.location.href = "/playing/overall?room=" + roomID;
     }

--- a/src/main/resources/templates/playing/host/quiz_result.html
+++ b/src/main/resources/templates/playing/host/quiz_result.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>Quiz_7/クイズ結果</title>
+  <link rel="stylesheet" href="/css/origin.css" />
+</head>
+
+<body>
+  <div class="container">
+    <div class="display">
+      <h3 th:if="${pgameroom}" th:text="${pgameroom.gameRoomName}"></h3>
+      <h3>出題したクイズ</h3>
+      <div th:if="${curQuiz}">
+        <p>タイトル:[[${curQuiz.title}]]</p>
+        <p>問題文:[[${curQuiz.description}]]</p>
+      </div>
+      <p>選択肢</p>
+      <div th:if="${curQuizJson}">
+        <ol>
+          <li th:each="choice : ${curQuizJson.choices}" th:text="${choice}"></li>
+        </ol>
+        <p>答え：[[${curQuizJson.correct}]]</p>
+      </div>
+      <a th:href="@{/playing/wait(room=${pgameroom.gameRoomID})}">次のクイズへ</a>
+    </div>
+
+    <div class="iframe-section">
+      <iframe th:src="@{./ranking}"></iframe>
+    </div>
+
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
Close #54 

開発内容
- PlayingController に get_quiz_result() メソッドを実装
  - GetMapping が iframe のランキングページと被るので名称を変更
  （/playing/quiz_result/room=（ルームID）&quiz=（クイズID）へのリクエストで表示される）
  - 併せて HostAnsResult.js 内のページ遷移先URLも変更
- /playing/host/quiz_result.html を作成
  - ランキングの表示には iframe のランキングページを利用
  - 出題したクイズの情報も表示するようにした（DoDに追加済）
- QuizTable の getQuizJSON が正しい JSON文字列を返すよう修正