### PR TITLE
解答時間終了によるゲーム的処理の実装 の完了

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -520,6 +520,9 @@ public class PlayingController {
       logger.info(logSB.toString());
     }
 
+    logger.info("postStartQuiz(...): Start AsyncPGameRoomService.asyncTimeupGameProc()");
+    asyncPGRService.asyncTimeupGameProc(roomID);
+
     return "redirect:/playing/ans_result";
   }
 }

--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -355,7 +355,7 @@ public class PlayingController {
   @GetMapping("/answer")
   public String getAnswerPage(@RequestParam("room") final long roomID, Principal prin, ModelMap model) {
     // [エラー] 対象の公開ゲームルームが解答中でない場合．
-    if (false && !(pGameRoomManager.getPublicGameRooms().get(roomID).isAnswering())) {
+    if (!(pGameRoomManager.getPublicGameRooms().get(roomID).isAnswering())) {
       return "/error";
     }
 

--- a/src/main/java/oit/is/team7/quiz_7/model/GameRoomParticipant.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/GameRoomParticipant.java
@@ -10,6 +10,7 @@ public class GameRoomParticipant {
   private long userID;
   private String userName;
   private long point = 0L;
+  private long pointDiff = 0L;
   private boolean answered;
   private long answerTime_ms;
   private AnswerObj answerContent;
@@ -36,6 +37,18 @@ public class GameRoomParticipant {
 
   public void setPoint(long point) {
     this.point = point;
+  }
+
+  public void addPoint(long point) {
+    this.point += point;
+  }
+
+  public long getPointDiff() {
+    return pointDiff;
+  }
+
+  public void setPointDiff(long pointDiff) {
+    this.pointDiff = pointDiff;
   }
 
   public boolean isAnswered() {

--- a/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
+++ b/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
@@ -294,7 +294,10 @@ public class AsyncPGameRoomService {
     }
     targetRoom.getRanking().sortByPoint();
 
+    // クイズインデックスのインクリメント
     targetRoom.incrementNextQuizIndex();
+
+    // 結果確定フラグのセット
     targetRoom.confirmResult();
 
     return;

--- a/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
+++ b/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
@@ -189,7 +189,7 @@ public class AsyncPGameRoomService {
       emitter.complete();
     }
   }
-  
+
   public void cancelGameRoom(long roomID) {
     logger.info("cancelGameRoom called with roomID: " + roomID);
     PublicGameRoom pgroom = pGameRoomManager.getPublicGameRooms().get(roomID);
@@ -231,5 +231,10 @@ public class AsyncPGameRoomService {
     } finally {
       emitter.complete();
     }
+  }
+
+  @Async
+  public void asyncTimeupGameProc(final long roomID) {
+    
   }
 }

--- a/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
+++ b/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
@@ -18,9 +18,14 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import oit.is.team7.quiz_7.model.PublicGameRoom;
+import oit.is.team7.quiz_7.model.QuizJson;
+import oit.is.team7.quiz_7.model.QuizTable;
 import oit.is.team7.quiz_7.model.QuizTableMapper;
+import oit.is.team7.quiz_7.model.AnswerObj;
+import oit.is.team7.quiz_7.model.AnswerObjImpl_4choices;
 import oit.is.team7.quiz_7.model.GameRoomParticipant;
 import oit.is.team7.quiz_7.model.PGameRoomManager;
+import oit.is.team7.quiz_7.model.PGameRoomRankingEntryBean;
 
 @Service
 public class AsyncPGameRoomService {
@@ -235,6 +240,63 @@ public class AsyncPGameRoomService {
 
   @Async
   public void asyncTimeupGameProc(final long roomID) {
-    
+    PublicGameRoom targetRoom = pGameRoomManager.getPublicGameRooms().get(roomID);
+    final long quizID = pGameRoomManager.getPublicGameRooms().get(roomID).getNextQuizID();
+    final QuizTable quiz = quizTableMapper.selectQuizTableByID((int) quizID);
+    final long timelimit_ms = (long) (quiz.getTimelimit() * 1000L);
+
+    // 解答残り時間が0以下になったとき，またはその公開ゲームルームの全参加者の解答が完了したときまで以降の処理を待機．
+    while(true) {
+      if(targetRoom.getElapsedAnswerTime_ms() > timelimit_ms) break;
+
+      int answeredNum = 0;
+      for(GameRoomParticipant ptc : targetRoom.getParticipants().values()) {
+        if(ptc.isAnswered()) answeredNum++;
+      }
+      if(targetRoom.getParticipants().size() <= answeredNum) break;
+
+      try {
+        TimeUnit.MILLISECONDS.sleep(500L);
+      } catch(Exception e) {
+        logger.error("asyncTimeupGameProc Error: " + e.getClass().getName() + ":" + e.getMessage());
+      }
+    }
+
+    // 解答終了(解答中フラグをfalseに)
+    targetRoom.endAnswer();
+
+    // 得点計算(4択クイズ) & ランキング更新
+    ObjectMapper objectMapper = new ObjectMapper();
+    String quizJsonString = quiz.getParsableQuizJSON();
+    int correctNum = 0;
+    try {
+      QuizJson quizJson = objectMapper.readValue(quizJsonString, QuizJson.class);
+      correctNum = quizJson.getCorrect();
+    } catch (Exception e) {
+      logger.error("Error at parsing quizJson: " + e.toString());
+    }
+    for(GameRoomParticipant ptc : targetRoom.getParticipants().values()) {
+      long calcPoint = 0L;
+      AnswerObj ans = ptc.getAnswerContent();
+
+      if(ans != null && ((AnswerObjImpl_4choices)ans).getAnsValue() == correctNum) {
+        calcPoint = (long)((double)quiz.getPoint() * (1.0 - ((double)ptc.getAnswerTime_ms() / timelimit_ms)));
+      } else {
+        calcPoint = 0L;
+      }
+
+      ptc.setPointDiff(calcPoint);
+      ptc.addPoint(calcPoint);
+
+      PGameRoomRankingEntryBean ptc_entry = targetRoom.getRanking().getEntry(ptc.getUserID());
+      ptc_entry.point = ptc.getPoint();
+      targetRoom.getRanking().setEntry(ptc_entry);
+    }
+    targetRoom.getRanking().sortByPoint();
+
+    targetRoom.incrementNextQuizIndex();
+    targetRoom.confirmResult();
+
+    return;
   }
 }


### PR DESCRIPTION
Close #76

### [概要]
　タスク「解答時間終了によるゲーム的処理の実装」(#76) の実装を行ったPR．
　タスク詳細は対応するIssueを確認してもらいたい．

### [レビュアー]
- e1b22103

### [DoD]
　※PRと同名のIssueに記載済みなので省略．

### [重要事項]
　実装部分へのコメントアウトは要請あれば行うものとします．
　当該Issueに追記しているが，動作的に確認できないDoDが存在すると考えている．それに関しては以後のシステムテストで確かめられたら良いと考えており，今回のレビューでは無視しても良い．

### [実行/実装事項]
　(省略，PRのFiles changedを参照されたい)
　実装内容は余力あれば記載する．もしくは，要請あれば記載する．

### [以降の開発についてのメモ]
　このタスクの完了をもってして，「_/playing/ans_result_」の表示の完成をはじめとした全体的な結合そしてシステムテストが可能になると思います．

### [備考]
　(なし)
