### PR TITLE
[参加者]解答結果表示ページ(/playing/ans_result)の結果表示項目不足の仕上げ

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.Logger;
 
 import oit.is.team7.quiz_7.model.Gameroom;
 import oit.is.team7.quiz_7.model.GameroomMapper;
+import oit.is.team7.quiz_7.model.AnswerObj;
 import oit.is.team7.quiz_7.model.AnswerObjImpl_4choices;
 import oit.is.team7.quiz_7.model.GameRoomParticipant;
 import oit.is.team7.quiz_7.model.PGameRoomManager;
@@ -144,9 +145,18 @@ public class PlayingController {
     try {
       QuizJson quizJson = objectMapper.readValue(quizJsonString, QuizJson.class);
       model.addAttribute("currentQuizJson", quizJson);
+
+      AnswerObj yourAnswer = participant.getAnswerContent();
+      if(yourAnswer != null) {
+        model.addAttribute("yourAnsContent", quizJson.getChoices()[((AnswerObjImpl_4choices)yourAnswer).getAnsValue() - 1]);
+        model.addAttribute("yourAnsTime", String.format("%.2f", ((double) ((participant.getAnswerTime_ms() + 9L) / 10L) / 100.0)));
+      }
     } catch (Exception e) {
       logger.error("Error at parsing quizJson: " + e.toString());
     }
+
+    model.addAttribute("yourGetPoint", participant.getPointDiff());
+
     return "/playing/guest/ans_result.html";
   }
 

--- a/src/main/resources/templates/playing/guest/ans_result.html
+++ b/src/main/resources/templates/playing/guest/ans_result.html
@@ -46,14 +46,14 @@
           <li th:each="choice, iterStat : ${currentQuizJson.choices}" th:text="${choice}"
             th:classappend="${iterStat.index == currentQuizJson.correct - 1} ? 'correct-choice' : ''"></li>
         </ol>
-        <p>あなたの回答: （取得付加）</p>
+        <p>あなたの回答: <span th:if="${yourAnsContent}" th:text="${yourAnsContent}"></span><span th:unless="${yourAnsContent}">-- 無回答 --</span></p>
         <p>正解: <span th:text="${currentQuizJson.choices[currentQuizJson.correct - 1]}"></span></p>
       </div>
       <div>
-        <p>解答時間: （取得付加）ms</p>
+        <p>解答時間: <span th:if="${yourAnsTime}" th:text="${yourAnsTime} + 's'"></span><span th:unless="${yourAnsTime}">-- s</span></p>
         <!-- <span th:text="${participant.answerTime}"></span> -->
         <p>解答順位: <span th:text="${answerTime_rank}"></span> 位</p>
-        <p>獲得点数: <span th:text="${currentQuiz.point}"></span> 点</p>
+        <p>獲得点数: <span th:text="${yourGetPoint}"></span> 点</p>
       </div>
 
       <a th:unless="${over_flag}" th:href="@{/playing/wait(room=${pgameroom.gameRoomID})}">続行</a>


### PR DESCRIPTION
### [概要]
　タイトルの通りに，未実装の結果表示項目の表示を仕上げとして実装．

### [実装結果]
　これにて，完全な[参加者]解答結果表示ページ(/playing/ans_result)の表示が成せていると思う．

### [実装内容]
- [参加者]解答結果表示ページ(/playing/ans_result)の表示項目「あなたの回答」を実装
- [参加者]解答結果表示ページ(/playing/ans_result)の表示項目「解答時間」を実装
- [参加者]解答結果表示ページ(/playing/ans_result)の表示項目「獲得点数」を実装