### PR TITLE
システムテスト(本番環境デバッグ)での不具合の修正

### DIFF
--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -72,6 +72,9 @@ public class PlayingController {
     pgroom.getRanking().sortByPoint();
     model.addAttribute("participant_rank", pgroom.getRanking().getEntry(userID).rank);
 
+    QuizTable nextQuiz = quizTableMapper.selectQuizTableByID((int)pgroom.getNextQuizID());
+    model.addAttribute("nextQuizTitle", nextQuiz.getTitle());
+
     return "/playing/guest/wait.html";
   }
 

--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -68,14 +68,10 @@ public class PlayingController {
     if (participant != null) {
       model.addAttribute("participant", participant);
     }
-    List<GameRoomParticipant> sortParticipants = new ArrayList<>(participants.values());
-    sortParticipants.sort((p1, p2) -> Long.compare(p2.getPoint(), p1.getPoint()));
-    for (int rank = 0; rank < sortParticipants.size(); rank++) {
-      GameRoomParticipant target = sortParticipants.get(rank);
-      if (target.getUserID() == userID) {
-        model.addAttribute("participant_rank", rank + 1);
-      }
-    }
+
+    pgroom.getRanking().sortByPoint();
+    model.addAttribute("participant_rank", pgroom.getRanking().getEntry(userID).rank);
+
     return "/playing/guest/wait.html";
   }
 
@@ -128,12 +124,15 @@ public class PlayingController {
     if (participant != null) {
       model.addAttribute("participant", participant);
     }
-    List<GameRoomParticipant> sortParticipants = new ArrayList<>(participants.values());
-    sortParticipants.sort((p1, p2) -> Long.compare((long) p1.getAnswerTime_ms(), (long) p2.getAnswerTime_ms()));
-    for (int rank = 0; rank < sortParticipants.size(); rank++) {
-      GameRoomParticipant target = sortParticipants.get(rank);
-      if (target.getUserID() == userID) {
-        model.addAttribute("answerTime_rank", rank + 1);
+
+    if(participant.isAnswered()) {
+      List<GameRoomParticipant> sortParticipants = new ArrayList<>(participants.values());
+      sortParticipants.sort((p1, p2) -> Long.compare((long) p1.getAnswerTime_ms(), (long) p2.getAnswerTime_ms()));
+      for (int rank = 0; rank < sortParticipants.size(); rank++) {
+        GameRoomParticipant target = sortParticipants.get(rank);
+        if (target.getUserID() == userID) {
+          model.addAttribute("answerTime_rank", rank + 1);
+        }
       }
     }
 
@@ -237,14 +236,10 @@ public class PlayingController {
     if (participant != null) {
       model.addAttribute("participant", participant);
     }
-    List<GameRoomParticipant> sortParticipants = new ArrayList<>(participants.values());
-    sortParticipants.sort((p1, p2) -> Long.compare(p2.getPoint(), p1.getPoint()));
-    for (int rank = 0; rank < sortParticipants.size(); rank++) {
-      GameRoomParticipant target = sortParticipants.get(rank);
-      if (target.getUserID() == userID) {
-        model.addAttribute("participantRank", rank + 1);
-      }
-    }
+
+    pgroom.getRanking().sortByPoint();
+    model.addAttribute("participant_rank", pgroom.getRanking().getEntry(userID).rank);
+
     return "/playing/guest/overall.html";
   }
 

--- a/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
+++ b/src/main/java/oit/is/team7/quiz_7/controller/PlayingController.java
@@ -2,7 +2,6 @@ package oit.is.team7.quiz_7.controller;
 
 import java.security.Principal;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import org.slf4j.LoggerFactory;
@@ -129,7 +128,13 @@ public class PlayingController {
     }
 
     if(participant.isAnswered()) {
-      List<GameRoomParticipant> sortParticipants = new ArrayList<>(participants.values());
+      final ArrayList<GameRoomParticipant> participantsList = new ArrayList<>(participants.values());
+      ArrayList<GameRoomParticipant> sortParticipants = new ArrayList<>();
+
+      for(final GameRoomParticipant p : participantsList) {
+        if(p.isAnswered()) sortParticipants.add(p);
+      }
+
       sortParticipants.sort((p1, p2) -> Long.compare((long) p1.getAnswerTime_ms(), (long) p2.getAnswerTime_ms()));
       for (int rank = 0; rank < sortParticipants.size(); rank++) {
         GameRoomParticipant target = sortParticipants.get(rank);

--- a/src/main/java/oit/is/team7/quiz_7/model/AnswerData.java
+++ b/src/main/java/oit/is/team7/quiz_7/model/AnswerData.java
@@ -6,9 +6,16 @@ public class AnswerData {
   private long answerTime_ms;
 
   public AnswerData(GameRoomParticipant participant, AnswerObjImpl_4choices answerObj) {
-    this.userName = participant.getUserName();
-    this.answerContent = (int) answerObj.getAnsValue();
-    this.answerTime_ms = participant.getAnswerTime_ms();
+    if(answerObj == null) {
+      // nullの場合，無効値を代入．
+      this.userName = participant.getUserName();
+      this.answerContent = -1;
+      this.answerTime_ms = -1L;
+    } else {
+      this.userName = participant.getUserName();
+      this.answerContent = (int) answerObj.getAnsValue();
+      this.answerTime_ms = participant.getAnswerTime_ms();
+    }
   }
 
   public String getUserName() {

--- a/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
+++ b/src/main/java/oit/is/team7/quiz_7/service/AsyncPGameRoomService.java
@@ -73,9 +73,6 @@ public class AsyncPGameRoomService {
       for (GameRoomParticipant participant : participants) {
         AnswerObjImpl_4choices ansObj = (AnswerObjImpl_4choices) participant.getAnswerContent();
         logger.info("AnswerObj: " + ansObj);
-        if (ansObj == null) {
-          continue;
-        }
         AnswerData ansData = new AnswerData(participant, ansObj);
         logger.info("AnswerData: " + ansData);
         answerDataList.add(ansData);

--- a/src/main/resources/static/js/HostAnsResult.js
+++ b/src/main/resources/static/js/HostAnsResult.js
@@ -23,10 +23,10 @@ class HostAnsResult {
       } else {
         let answerList = "<tbody>";
         answerDataList.forEach((answerData) => {
-          if (answerData.answerContent === null) {
+          if (answerData.answerContent < 0) {
             answerList += "<tr><td>" + answerData.userName + "</td><td>未解答</td><td align='right'>----</td></tr>";
           } else {
-            answerList += "<tr><td>" + answerData.userName + "</td><td align='right'>" + answerData.answerContent + "</td><td align='right'>" + (answerData.answerTime_ms　/　1000) + "秒</td></tr>";
+            answerList += "<tr><td>" + answerData.userName + "</td><td align='right'>" + answerData.answerContent + "</td><td align='right'>" + (answerData.answerTime_ms / 1000) + "秒</td></tr>";
           }
         });
         answerList += "</tbody>";

--- a/src/main/resources/templates/playing/guest/ans_result.html
+++ b/src/main/resources/templates/playing/guest/ans_result.html
@@ -50,9 +50,9 @@
         <p>正解: <span th:text="${currentQuizJson.choices[currentQuizJson.correct - 1]}"></span></p>
       </div>
       <div>
-        <p>解答時間: <span th:if="${yourAnsTime}" th:text="${yourAnsTime} + 's'"></span><span th:unless="${yourAnsTime}">-- s</span></p>
+        <p>解答時間: <span th:if="${yourAnsTime}" th:text="${yourAnsTime}"></span><span th:unless="${yourAnsTime}">--</span> s</p>
         <!-- <span th:text="${participant.answerTime}"></span> -->
-        <p>解答順位: <span th:text="${answerTime_rank}"></span> 位</p>
+        <p>解答順位: <span th:if="${answerTime_rank}" th:text="${answerTime_rank}"></span><span th:unless="${answerTime_rank}">--</span> 位</p>
         <p>獲得点数: <span th:text="${yourGetPoint}"></span> 点</p>
       </div>
 

--- a/src/main/resources/templates/playing/guest/overall.html
+++ b/src/main/resources/templates/playing/guest/overall.html
@@ -13,7 +13,7 @@
       <h3 th:if="${pgameroom}" th:text="${pgameroom.gameRoomName}"></h3>
       <div th:if="${participant}">
         <p>[[${participant.userName}]] さんの</p>
-        <p>最終順位：[[${participantRank}]]位</p>
+        <p>最終順位：[[${participant_rank}]]位</p>
         <p>最終得点：[[${participant.point}]]点</p>
       </div>
       <a th:href="@{/main}">メインページ</a>

--- a/src/main/resources/templates/playing/guest/wait.html
+++ b/src/main/resources/templates/playing/guest/wait.html
@@ -25,6 +25,7 @@
     <div class="display">
       <h3 th:if="${pgameroom}" th:text="${pgameroom.gameRoomName}"></h3>
       <h2>クイズの出題を待っています</h2>
+      <h3 th:if="nextQuizTitle">次の問題タイトル: [[${nextQuizTitle}]]</h3>
       <div th:if="${participant}">
         <p>[[${participant.userName}]] さんの</p>
         <p>現在の順位：[[${participant_rank}]]位</p>

--- a/src/main/resources/templates/register_useracc.html
+++ b/src/main/resources/templates/register_useracc.html
@@ -21,7 +21,7 @@
       <div th:if="${result}" th:text="${result}" />
       <form th:action="@{/register_useracc/send}" method="post">
         <label for="username">ユーザ名:</label><br>
-        <input type="text" name="username" required><br>
+        <input type="text" name="username" maxlength="20" required><br>
         <label for="password">パスワード:</label><br>
         <input type="password" name="password" required><br>
         <button type="submit" class="colored_button">登録</button>


### PR DESCRIPTION
### [概要]
　本日行ったシステムテストで発見された細かな不具合を修正．システムテスト時に書いたメモの項目をすべて修正したと思う．

### [実装結果]
　従来の動作を保ちながら，次に示す実装内容の改良・改善を行っている．

### [実装内容]
- [参加者] 出題待機ページ(_/playing/wait_)の「参加者の現在得点順位の表示」のデータ源を「公開ゲームルームクラス内部のランキング(PublicGameRoom.ranking)」に変更．
- [参加者] 解答結果表示ページ(_/playing/ans_result_)の「参加者の解答順位の表示」の評価対象者を解答者に限定．
- [参加者] 最終結果表示ページ(_/playing/overall_)の「参加者の最終得点順位の表示」のデータ源を「公開ゲームルームクラス内部のランキング(PublicGameRoom.ranking)」に変更．
- [主催者] 解答待機ページ(_/playing/ans_result_)の無回答者の解答状況が非表示になる不具合を修正．
- [参加者] 出題待機ページ(_/playing/wait_)の画面(ページ)に「次の問題タイトル」の項目を新たに表示．
- ユーザ新規登録ページのhtml側でのユーザ名文字数制限(20)の追加